### PR TITLE
feat(Sticker): feat: add StickerBody Component

### DIFF
--- a/packages/client/src/dashboard/presentation/components/Sticker/StickerBody.tsx
+++ b/packages/client/src/dashboard/presentation/components/Sticker/StickerBody.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import PieChart from '../Charts/PieChart';
+
+type contentType = 'Table' | 'PieChart' | 'BarChart' | 'LineChart';
+
+interface StickerBodyProps {
+  content: contentType;
+  dataSet?: any;
+  colorSet?: any;
+}
+
+const Content = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100% - 3rem);
+  width: calc(100% - 1rem);
+  padding: 0.5rem;
+`;
+
+// TODO(hybae)
+// Support other charts and table with dataset in Content component
+const contentSwitch = (type: contentType) => {
+  switch (type) {
+    case 'Table':
+      break;
+    case 'PieChart':
+      return <PieChart></PieChart>;
+    case 'BarChart':
+      break;
+    case 'LineChart':
+      break;
+    default:
+      break;
+  }
+};
+
+export const StickerBody = (props: StickerBodyProps) => {
+  const { content } = props;
+  return <Content>{contentSwitch(content)}</Content>;
+};


### PR DESCRIPTION
StickerBody Component 추가

#90

### 작업 동기 (Motivation)
- Sticker 내 차트 또는 테이블이 보여질 영역 필요

### 변경 사항 요약 (Key changes)
- 차트 종류나 테이블을 props로 받아 해당 컨텐츠를 보여주는 StickerBody Component 추가

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [x] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부
<img width="505" alt="스크린샷 2022-06-30 오후 4 24 24" src="https://user-images.githubusercontent.com/62418146/176618132-2e9d3c90-0b9d-44f3-8606-0ea582c68447.png">

### 리뷰어들에게 요청사항

