### PR TITLE
fix(client/charts): fix build error

### DIFF
--- a/packages/client/src/dashboard/presentation/components/Charts/PieChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/PieChart.tsx
@@ -26,6 +26,6 @@ export function StoryPieChart(props: PieChartProps) {
   return <Pie data={props.data} options={props.options} />;
 }
 
-export function PieChart() {
+export default function PieChart() {
   return <Pie data={data} options={options} />;
 }


### PR DESCRIPTION
- PieChart function에 default를 붙여 Sticker에서 import할 때 build error가 난것을 고쳤습니다.

### 작업 동기 (Motivation)
main으로 merge를 했을 때 git action build error가 났습니다.
### 변경 사항 요약 (Key changes)
🐛 버그 픽스인 경우 :
- 버그의 발생 원인? 코드를 수정하면서 Sticker 파트에서 쓰는 PieChart function에 default로 export를 하지 않았습니다.
- 어떻게 해결했는가? PieChart export에서 default를 붙여주었습니다.
### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).
