### PR TITLE
feat(Sticker): feat: Sticker Component 추가

### DIFF
--- a/packages/client/src/dashboard/presentation/components/Board/Section.tsx
+++ b/packages/client/src/dashboard/presentation/components/Board/Section.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import './styles.css';
 import './styles2.css';
 import RGL, { Layout, WidthProvider } from 'react-grid-layout';
+import { Sticker } from '../Sticker/Sticker';
 
 const ReactGridLayout = WidthProvider(RGL.Responsive);
 
@@ -12,7 +13,11 @@ export default function Section(props: any) {
 
   function generateSticker() {
     return layout.map((item: Layout) => {
-      return <div key={item.i}>{<span className="text">{item.i}</span>}</div>;
+      return (
+        <div key={item.i}>
+          <Sticker content="PieChart"></Sticker>
+        </div>
+      );
     });
   }
 

--- a/packages/client/src/dashboard/presentation/components/Sticker/Sticker.tsx
+++ b/packages/client/src/dashboard/presentation/components/Sticker/Sticker.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Header } from '../Common/Header';
+import { StickerBody } from './StickerBody';
+
+type contentType = 'Table' | 'PieChart' | 'BarChart' | 'LineChart';
+
+interface StickerProps {
+  content: contentType;
+}
+
+const StickerWrapper = styled.div`
+  height: 100%;
+`;
+
+export const Sticker = (props: StickerProps) => {
+  const { content } = props;
+  return (
+    <StickerWrapper>
+      <Header parentComponent="STICKER"></Header>
+      <StickerBody content={content}></StickerBody>
+    </StickerWrapper>
+  );
+};


### PR DESCRIPTION
Header, StickerBody를 포함한 Sticker Component 추가

#88

### 작업 동기 (Motivation)
- 차트 및 테이블을 보여주기 위한 Sticker 필요

### 변경 사항 요약 (Key changes)
- Header, StickerBody를 포함한 Sticker Component 생성
- Section에서 Sticker 추가 시, 임의의 데이터(PieChart)가 포함된 Sticker를 생성하도록 수정

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

