### PR TITLE
fix(server): fixed: progress entity type changed

### DIFF
--- a/packages/server/src/app.module.ts
+++ b/packages/server/src/app.module.ts
@@ -39,5 +39,5 @@ import { DataSource } from 'typeorm';
   providers: [AppService],
 })
 export class AppModule {
-  constructor(private dataSource: DataSource) {}
+  // constructor(private dataSource: DataSource) {}
 }

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -203,7 +203,7 @@ type UserProcessProgress {
 
 type UserReasonOfBreak {
   created_date: DateTime!
-  date_of_break: Float
+  date_of_break: DateTime!
   pk: Float!
-  reason_of_break: DateTime!
+  reason_of_break: String
 }

--- a/packages/server/src/user_information/user_information.service.ts
+++ b/packages/server/src/user_information/user_information.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { UserAccessCardInformation } from 'src/user_information/entity/user_access_card_information.entity';
 import { User } from 'src/user_information/entity/user_information.entity';
 import { UserOtherInformation } from 'src/user_information/entity/user_other_information.entity';
@@ -45,6 +45,7 @@ export class UserInformationService {
     private userOtherRepository: Repository<UserOtherInformation>,
     @InjectRepository(UserAccessCardInformation)
     private userAccessCardRepository: Repository<UserAccessCardInformation>,
+    @InjectDataSource()
     private dataSource: DataSource,
   ) {
     this.operatorToMethod = {};

--- a/packages/server/src/user_status/entity/user_status.entity.ts
+++ b/packages/server/src/user_status/entity/user_status.entity.ts
@@ -187,18 +187,18 @@ export class UserReasonOfBreak extends BaseEntity {
   @PrimaryGeneratedColumn({ name: 'pk' })
   pk: number;
 
-  @Field({ nullable: true })
-  @Column({ name: 'date_of_break', nullable: true })
-  date_of_break: number;
-
   @Field({ nullable: false, defaultValue: '9999-12-31' })
   @Column({
-    name: 'reason_of_break',
+    name: 'date_of_break',
     nullable: false,
     default: '9999-12-31',
     type: 'date',
   })
-  reason_of_break: Date;
+  date_of_break: Date;
+
+  @Field({ nullable: true })
+  @Column({ name: 'reason_of_break', nullable: true })
+  reason_of_break: string;
 
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })


### PR DESCRIPTION
- 진행상황의 자료형을 변경하고, datasource에 종속성주입을 하였습니다.
 - 1600명 목업데이터로 파싱확인했습니다.

fix #125

### 작업 동기 (Motivation)
- 1600명 데이터를 추출하기 위해 모든 컬럼에 목업데이터를 구성하여 파싱테스트를 하고자 했습니다.

### 변경 사항 요약 (Key changes)
- 엔티티의 타입변경
- Datasource의 종속성주입

### 체크리스트
- [x] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/55140432/176884934-0e3cbbf8-59a9-4f18-8653-45b9e8e90e7d.png">

### 리뷰어들에게 요청사항

