### PR TITLE
style(userAccessCardInformationArgs): style: change column name

### DIFF
--- a/packages/server/src/updater/name_types/updater.name.ts
+++ b/packages/server/src/updater/name_types/updater.name.ts
@@ -76,19 +76,19 @@ export const mapObj = [
     { spName: '출입카드정보 사진이미지파일', dbName: 'profile_picture_url' },
     {
       spName: '라피신출입카드물리번호',
-      dbName: 'lapiscine_access_card_number_of_physical',
+      dbName: 'lapiscine_physical_number',
     },
     {
       spName: '라피신출입카드논리번호',
-      dbName: 'lapiscine_access_card_number_of_logical',
+      dbName: 'lapiscine_logical_number',
     },
     {
       spName: '본과정출입카드논리번호',
-      dbName: 'logical_number_of_access_card_for_this_course',
+      dbName: 'logical_number_for_main_course',
     },
     {
       spName: '본과정출입카드명',
-      dbName: 'name_of_entry_card_for_this_course',
+      dbName: 'name_of_entry_card_for_main_course',
     },
   ],
 ];

--- a/packages/server/src/user_information/argstype/userAccessCardInformation.ts
+++ b/packages/server/src/user_information/argstype/userAccessCardInformation.ts
@@ -17,16 +17,16 @@ export class GetUserAccessCardInformationArgs {
   profile_picture_path: string;
 
   @Field((type) => Int, { nullable: true })
-  lapiscine_access_card_number_of_physical: number;
+  lapiscine_physical_number: number;
 
   @Field((type) => Int, { nullable: true })
-  lapiscine_access_card_number_of_logical: number;
+  lapiscine_logical_number: number;
 
   @Field((type) => Int, { nullable: true })
-  logical_number_of_access_card_for_this_course: number;
+  logical_number_for_main_course: number;
 
   @Field({ nullable: true })
-  name_of_entry_card_for_this_course: string;
+  name_of_entry_card_for_main_course: string;
 
   @Field({ nullable: true })
   created_date: Date;

--- a/packages/server/src/user_information/entity/user_access_card_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_access_card_information.entity.ts
@@ -23,23 +23,23 @@ export class UserAccessCardInformation extends BaseEntity {
   profile_picture_path: string;
 
   @Field((type) => Int)
-  @Column({ name: 'lapiscine_access_card_number_of_physical', nullable: true })
-  lapiscine_access_card_number_of_physical: number;
+  @Column({ name: 'lapiscine_physical_number', nullable: true })
+  lapiscine_physical_number: number;
 
   @Field((type) => Int)
-  @Column({ name: 'lapiscine_access_card_number_of_logical', nullable: true })
-  lapiscine_access_card_number_of_logical: number;
+  @Column({ name: 'lapiscine_logical_number', nullable: true })
+  lapiscine_logical_number: number;
 
   @Field((type) => Int)
   @Column({
-    name: 'logical_number_of_access_card_for_this_course',
+    name: 'logical_number_for_main_course',
     nullable: true,
   })
-  logical_number_of_access_card_for_this_course: number;
+  logical_number_for_main_course: number;
 
   @Field()
-  @Column({ name: 'name_of_entry_card_for_this_course', nullable: true })
-  name_of_entry_card_for_this_course: string;
+  @Column({ name: 'name_of_entry_card_for_main_course', nullable: true })
+  name_of_entry_card_for_main_course: string;
 
   @Field()
   @CreateDateColumn({ name: 'created_date' })

--- a/packages/server/src/user_information/entity/user_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_information.entity.ts
@@ -264,17 +264,17 @@ export class User {
 //     @Column({name: "profile_picture", nullable: true })
 //     profile_picture: string;
 
-//     @Column({name: "lapiscine_access_card_number_of_physical", nullable: true })
-//     lapiscine_access_card_number_of_physical: number;
+//     @Column({name: "lapiscine_physical_number", nullable: true })
+//     lapiscine_physical_number: number;
 
-//     @Column({name: "lapiscine_access_card_number_of_logical", nullable: true})
-//     lapiscine_access_card_number_of_logical: number;
+//     @Column({name: "lapiscine_logical_number", nullable: true})
+//     lapiscine_logical_number: number;
 
-//     @Column({name: "logical_number_of_access_card_for_this_course", nullable: true })
-//     logical_number_of_access_card_for_this_course: number;
+//     @Column({name: "logical_number_for_main_course", nullable: true })
+//     logical_number_for_main_course: number;
 
-//     @Column({name: "name_of_entry_card_for_this_course", nullable: true })
-//     name_of_entry_card_for_this_course: string;
+//     @Column({name: "name_of_entry_card_for_main_course", nullable: true })
+//     name_of_entry_card_for_main_course: string;
 
 //     @Column({name: "created_date", nullable: false })
 //     created_date: Date;


### PR DESCRIPTION
테이블 컬럼의 긴 이름과 불명확한 해석을 수정하였습니다

style #138

### 작업 동기 (Motivation)
API 명세를 작성하기 위해 테이블 컬럼을 수정하였습니다. 

### 변경 사항 요약 (Key changes)
- 테이블 컬럼 수정
    - ex) lapiscine_access_card_number_of_physical -> lapiscine_physical_number 
### 체크리스트
- [x] 컬럼 이름 해석이 제대로 됐는지

### 스크린샷 첨부
![image](https://user-images.githubusercontent.com/55140432/177082417-4b427195-97d7-4f15-95ec-ba221a4999a1.png)

![image](https://user-images.githubusercontent.com/55140432/177082397-8213a94c-3662-4f88-a543-7376e46d64dd.png)


### 리뷰어들에게 요청사항

