### PR TITLE
feat(server): or 연산자 일부 지원

### DIFF
--- a/packages/server/src/user_information/user_information.service.spec.ts
+++ b/packages/server/src/user_information/user_information.service.spec.ts
@@ -49,6 +49,33 @@ const userBlackholeObject = {
       reason_of_blackhole: null,
       blackhole_date: new Date('2021-01-01'),
     },
+    {
+      remaining_period: 88,
+      reason_of_blackhole: null,
+      blackhole_date: new Date('2021-01-01'),
+    },
+    {
+      remaining_period: 87,
+      reason_of_blackhole: null,
+      blackhole_date: new Date('2021-01-01'),
+    },
+  ],
+  2: [
+    {
+      remaining_period: 200,
+      reason_of_blackhole: null,
+      blackhole_date: new Date('2021-01-01'),
+    },
+    {
+      remaining_period: 199,
+      reason_of_blackhole: null,
+      blackhole_date: new Date('2021-01-01'),
+    },
+    {
+      remaining_period: 198,
+      reason_of_blackhole: null,
+      blackhole_date: new Date('2021-01-01'),
+    },
   ],
 };
 
@@ -123,14 +150,15 @@ describe('User Service', () => {
   });
 
   it('필터 [region = 부산]', async () => {
-    //given
+    // given
     await queryRunner.startTransaction();
-    //when
+    // when
     const filters = [];
     filters.push(
       makeFilter('userPersonalInformation', 'region', '=', '부산', true),
     );
-    //then
+    // then
+    console.log(await userService.getPeopleByFiter(filters));
     expect(await userService.getNumOfPeopleByFilter(filters)).not.toBeNull();
     expect(await userService.getNumOfPeopleByFilter(filters)).toBe(2);
     await queryRunner.rollbackTransaction();

--- a/packages/server/src/user_information/user_information.service.ts
+++ b/packages/server/src/user_information/user_information.service.ts
@@ -57,9 +57,15 @@ export class UserInformationService {
     this.operatorToMethod['='] = Equal;
     this.operatorToMethod['!='] = Not;
     this.operatorToMethod['Like'] = Like;
+    this.operatorToMethod['like'] = Like;
     this.operatorToMethod['ILike'] = ILike;
+    this.operatorToMethod['iLike'] = ILike;
+    this.operatorToMethod['ilike'] = ILike;
+    this.operatorToMethod['Ilike'] = ILike;
     this.operatorToMethod['In'] = In;
+    this.operatorToMethod['in'] = In;
     this.operatorToMethod['Any'] = Any;
+    this.operatorToMethod['any'] = Any;
     this.operatorToMethod['null'] = IsNull;
   }
 
@@ -121,6 +127,7 @@ export class UserInformationService {
     }
     // console.log(filterObj);
     const obj = this.getObj(filterObj);
+    console.log(obj);
     obj['cache'] = true; //typeORM에서 제공하는 cache 기능
     obj['order'] = { intra_id: 'ASC', grade: 'ASC' }; //정렬할 필요가 있는건지?
     return { obj, filterObj };
@@ -247,6 +254,7 @@ export class UserInformationService {
   private getObj(filterObj) {
     let filter;
     let column;
+    let operator;
     const ret = {};
     ret['relations'] = {};
     ret['where'] = {};
@@ -254,8 +262,12 @@ export class UserInformationService {
     if ('user' in filterObj) {
       for (const idx in filterObj['user']) {
         filter = filterObj['user'][idx];
+        operator = filter['operator'];
         column = filter['column'];
         if (column == null) continue; // 예외처리
+        if (operator == 'In' || operator == 'in') {
+          filter['givenValue'] = filter['givenValue'].split(';');
+        }
         ret['where'][column] = this.operatorToORMMethod(filter['operator'])(
           filter['givenValue'],
         ); //overwrite issue 발생가능(명세서에 적어줘야함)
@@ -268,8 +280,13 @@ export class UserInformationService {
       ret['order'][entityName] = {};
       for (const idx in filterObj[entityName]) {
         filter = filterObj[entityName][idx];
+        operator = filter['operator'];
+        console.log('given value: ', filter['operator']);
         column = filter['column'];
-        if (column == null) continue;
+        if (column == null) continue; // 예외처리
+        if (operator == 'In' || operator == 'in') {
+          filter['givenValue'] = filter['givenValue'].split(';');
+        }
         ret['where'][entityName][column] = this.operatorToORMMethod(
           filter['operator'],
         )(filter['givenValue']); //overwrite issue 발생가능(명세서에 적어줘야함)


### PR DESCRIPTION
In 연산자를 지원하여 필터링시 or연산이 일부 가능하게 구현을 해놓았습니다

feat #143

### 작업 동기 (Motivation)

### 변경 사항 요약 (Key changes)
var In [1, 2, 3] 은 var이 1또는 2또는 3일때 true인 연산인데, 이 연산을 지원하게 하여
기수 In ["1기", "2기", "3기"] 등의 필터링이 가능하게 하였습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [X] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

