### PR TITLE
fix(server): 오타 수정(lastest, fiter) 및 연산자 추가

### DIFF
--- a/packages/server/src/user_information/filter.ts
+++ b/packages/server/src/user_information/filter.ts
@@ -16,7 +16,7 @@ export class Filter {
   @Field()
   givenValue: string; //이렇게 물음표 안붙으면 필수값이라는 뜻
   @Field()
-  lastest: boolean;
+  latest: boolean;
   // @Field()
   // log?: boolean; //이렇게 물음표 붙이면 '필수값이 아니'라는 뜻
 }

--- a/packages/server/src/user_information/user_information.resolver.ts
+++ b/packages/server/src/user_information/user_information.resolver.ts
@@ -52,7 +52,7 @@ export class UserInformationResolver {
   // }
 
   @Query(() => [JoinedTable])
-  getPeopleByFiter(@Args() filterArg: FilterArgs) {
+  getPeopleByFilter(@Args() filterArg: FilterArgs) {
     return this.userService.getPeopleByFiter(filterArg.filters);
   }
 

--- a/packages/server/src/user_information/user_information.service.ts
+++ b/packages/server/src/user_information/user_information.service.ts
@@ -64,6 +64,8 @@ export class UserInformationService {
     this.operatorToMethod['Ilike'] = ILike;
     this.operatorToMethod['In'] = In;
     this.operatorToMethod['in'] = In;
+    this.operatorToMethod['Between'] = Between;
+    this.operatorToMethod['between'] = Between;
     this.operatorToMethod['Any'] = Any;
     this.operatorToMethod['any'] = Any;
     this.operatorToMethod['null'] = IsNull;
@@ -265,7 +267,12 @@ export class UserInformationService {
         operator = filter['operator'];
         column = filter['column'];
         if (column == null) continue; // 예외처리
-        if (operator == 'In' || operator == 'in') {
+        if (
+          operator == 'In' ||
+          operator == 'in' ||
+          operator == 'Between' ||
+          operator == 'between'
+        ) {
           filter['givenValue'] = filter['givenValue'].split(';');
         }
         ret['where'][column] = this.operatorToORMMethod(filter['operator'])(


### PR DESCRIPTION
오타 몇개를 수정하였습니다. 연산자 3개를 추가하였습니다 (between, like, ilike)연산자를 추가하였습니다

fix #157

### 작업 동기 (Motivation)

### 변경 사항 요약 (Key changes)
🐛 버그 픽스인 경우 :
- 버그를 재현하는 방법?: 오타에 의해서 발생한 버그입니다.
- 버그의 발생 원인?: 오타입니다.
- 어떻게 해결했는가?: 오타를 수정했습니다 죄송합니다.

✨ 그 외의 경우 :
- 적용된 변경 사항 요약
getPeopleByFiter 쿼리를 getPeopleByFilter로 오타수정. lastest -> latest 오타 수정
연산자 3개 수정 -> api 명세서에 설명을 적어 놓았습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [X] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

