### PR TITLE
feat(server): api 파싱하여 db에 저장

### DIFF
--- a/packages/server/src/api/api.controller.ts
+++ b/packages/server/src/api/api.controller.ts
@@ -16,10 +16,4 @@ export class ApiController {
     const api = await this.apiService.getApi();
     return api;
   }
-
-  // @Get('/doyun')
-  // getUserById(@Param('intra_id')intra_id: String) {
-  //     console.log("ishere");
-  //     return this.apiService.getUserById(intra_id);
-  // }
 }

--- a/packages/server/src/api/api.module.ts
+++ b/packages/server/src/api/api.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ApiController } from './api.controller';
 import { ApiResolver } from './api.resolver';
 import { ApiService } from './api.service';
+import { Api } from './entity/api.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Api])],
   controllers: [ApiController],
   providers: [ApiResolver, ApiService],
   //exports:[ApiService]

--- a/packages/server/src/api/api.service.ts
+++ b/packages/server/src/api/api.service.ts
@@ -5,13 +5,37 @@ import { raw } from 'body-parser';
 import { response } from 'express';
 import axios from 'axios';
 import { app_api, app_id, app_secret } from 'src/config/key';
+import { json } from 'stream/consumers';
+import { Api } from './entity/api.entity';
+import { Repository } from 'typeorm';
+import { CreateApiDto } from './dto/create-api.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { finished } from 'stream';
+import { UserLearningData } from 'src/user_status/entity/user_status.entity';
 
 @Injectable()
 export class ApiService {
-  // constructor(private readonly apiService: ApiService) {}
+  // constructor(
+  // //  @InjectRepository(Api)
+  // //  private readonly apiRepository: Repository<Api>,
+  // ) {}
 
-  async showBrowser() {
-    return console.log('hi');
+  ///////////////////////////////////////////////////////////////
+  /////////////////////////start get api/////////////////////////
+  ///////////////////////////////////////////////////////////////
+  async getApi() {
+    let token;
+    let api_data;
+    let parsed_api;
+    try {
+      token = await this.getToken();
+      api_data = await this.requestApi(token);
+      parsed_api = await this.parsingJson(api_data);
+    } catch {
+      throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
+    }
+
+    return parsed_api;
   }
 
   async getToken() {
@@ -34,41 +58,75 @@ export class ApiService {
   }
 
   async requestApi(token) {
-    let temp;
-    const auth_token = this.getCode();
-    const page_num = 1;
+    let api_data = [];
+    let page_num = 1;
 
-    //  console.log("인풋인자: token", token)
-    //  temp = token.get("https://api.intra.42.fr/v2/cursus_users").parsed;
-    // while(page < 3) {
-    temp = await axios({
-      method: 'get', // 요청 방식
-      //url: "https://api.intra.42.fr/v2/users/junghan",
-      //url: "https://api.intra.42.fr/v2/coalitions/124/users",
-      //url: "https://api.intra.42.fr/v2/users/junghan/locations_stats",
-      //url: "https://api.intra.42.fr/v2/dashes/124/users",
-      // url: "https://api.intra.42.fr/v2/events/124/users",
-      // url: "https://api.intra.42.fr/v2/accreditations/1/users",
-      //url: "https://api.intra.42.fr/v2/projects/8/users",
-      //url: "https://api.intra.42.fr/v2/cursus_users/graph/on/created_at/by/month", //cursus유저 생긴 수 확인하는 듯
-      url: `https://api.intra.42.fr/v2/cursus/21/cursus_users?filter[campus_id]=29&page[number]=${page_num}&page[size]=100`,
-      //url: `https://api.intra.42.fr/v2/cursus_users/?filter[campus_id]=29&page[number]=${page_num}&page[size]=100`,
+    while (1) {
+      const temp = await axios({
+        method: 'get', // 요청 방식
 
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    // console.log(temp);
-    temp = temp.data;
+        url: `https://api.intra.42.fr/v2/cursus/21/cursus_users?filter[campus_id]=29&page[number]=${page_num}&page[size]=100$sort=user_id`,
+        //url: 'https://api.intra.42.fr/v2/cursus_users/117025', //cursus_id 41값인 외국인 같음 grade도 null 임
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      //if (page_num == 20) console.log(temp.data[99]);
 
-    // console.log(temp);
-    //  page++;
-    //   }
-    //console.log("what is api",temp);
-    //return temp;
-    temp = await this.parsingJson(temp);
-    // console.log("grade: ",temp[0]);
-    return temp;
+      //    console.log(page_num);
+      // console.log('why ', temp.data.length);
+      console.log(page_num);
+
+      if (temp.data.length === 0) {
+        //(temp.data == null || temp.data == undefined) {
+        console.log('i got all data from 42api');
+        break;
+      }
+      //console.log(temp.data.user.staff);
+      //if (temp.data.user['staff?'] == true) continue;
+      api_data = api_data.concat(temp.data);
+      // console.log(temp.data);
+
+      // console.log('temp---', temp.data, `@@@@@@@@@@${page_num}`);
+      ++page_num;
+    }
+    /* console.log(
+      '---------------------',
+      api_data,
+      `-----------------------${page_num}`,
+    );*/
+    //console.log(temp.data.length === 0);
+    return api_data;
+  }
+
+  async parsingJson(api_data) {
+    const parsed_data = [];
+    let idx = 0;
+
+    for (const row in api_data) {
+      if (api_data[row].user['staff?'] == true) {
+        parsed_data[idx] = {};
+        parsed_data[idx]['intra_no'] = api_data[row].user.id;
+        parsed_data[idx]['intra_id'] = api_data[row].user.login;
+        parsed_data[idx]['level'] = api_data[row].level;
+        parsed_data[idx]['email'] = api_data[row].user.email;
+        parsed_data[idx]['phone_number'] = api_data[row].user.phone;
+        parsed_data[idx]['circle'] = 9999;
+        parsed_data[idx]['out_circle'] = api_data[row].grade;
+        parsed_data[idx]['out_circle_date'] = '9999-12-31';
+        parsed_data[idx]['coalition_score'] = 0;
+        //parsed_data[idx]['staff'] = api_data[row].user['staff?'];
+        parsed_data[idx]['blackhole_time'] = await this.parsingDate(
+          api_data[row].blackholed_at,
+        );
+        parsed_data[idx]['remaining_period'] = await this.calculateDate(
+          api_data[row].blackholed_at,
+        );
+        idx++;
+        console.log(parsed_data);
+      }
+    }
+    return parsed_data;
   }
 
   parsingDate(date): string {
@@ -80,11 +138,17 @@ export class ApiService {
     }
     const date_temp = new Date(date);
     // let year = date_temp.getUTCFullYear;
-    parsed_date = `${`${date_temp.getFullYear()}-${
-      date_temp.getMonth() + 1
-    }-${date_temp.getDate()}`}`;
-    // console.log(parsed_date);
-    return parsed_date;
+    const year = date_temp.getFullYear();
+    const tmpMonth = date_temp.getMonth() + 1;
+    const tmpDay = date_temp.getDate();
+    const month = tmpMonth >= 10 ? tmpMonth : '0' + tmpMonth;
+    const day = tmpDay >= 10 ? tmpDay : '0' + tmpDay;
+    return year + '-' + month + '-' + day;
+    // parsed_date = `${`${date_temp.getFullYear()}-${
+    //   date_temp.getMonth() + 1
+    // }-${date_temp.getDate()}`}`;
+    // // console.log(parsed_date);
+    // return parsed_date;
   }
 
   calculateDate(date) {
@@ -104,83 +168,254 @@ export class ApiService {
     const hour = minute / 60;
     const day = hour / 24;
     calculated_date = Math.floor(day); //소수점 버리는 것
-
-    // let year_to_day = (today.getUTCFullYear() - date_temp.getUTCFullYear()) * 365;
-    // let month_to_day = (today.getUTCFullYear() - date_temp.getUTCFullYear()) * ;
-    //    calculated_date = ((today.getUTCFullYear() - date_temp.getUTCFullYear()) * 365) + (today.getUTCFullYear() - date_temp.getUTCFullYear());
     return calculated_date;
   }
 
-  async parsingJson(api_json) {
-    const temp = [];
-    //   console.log(black);
-    //while(api_value[i] !== null){
-    for (const row in api_json) {
-      temp[row] = {};
-      temp[row]['level'] = api_json[row].level;
-      temp[row]['email'] = api_json[row].user.email;
-      temp[row]['phone'] = api_json[row].user.phone;
-      temp[row]['circle'] = 9999;
-      temp[row]['outercircle'] = api_json[row].grade;
-      temp[row]['outercircle_date'] = null;
-      temp[row]['coaltion_score'] = null;
-      temp[row]['blackhole_date'] = await this.parsingDate(
-        api_json[row].blackholed_at,
-      );
-      temp[row]['blackhole_remain_date'] = await this.calculateDate(
-        api_json[row].blackholed_at,
-      );
+  getTupleFromApi(intra_no: number, api42s) {
+    for (const api42 of api42s) {
+      //console.log(api42);
+      //   console.log('1', intra_no);
+      // console.log('2', api42.intra_no);
+      if (intra_no == api42.intra_no) {
+        // console.log(`we got intra no: ${intra_no}\n`);
+        return api42;
+      }
     }
-    console.log(temp[2].blackhole_remain_date);
-    //console.log(api_json);
-    //   let today = new Date();
-    //  console.log(today);
-    //   console.log(`${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`); //년과 일은 현지 시간대로 나타나지만 월같은 경우 0부터 시작, 요일도 0부터 시작
-    // console.log(temp[1]['blackhole_date']);
-    return temp;
+    console.log('cant find');
+    return -1;
   }
 
-  async getCode(): Promise<string> {
-    let temp;
-
-    temp = await axios({
-      method: 'get', // 요청 방식
-      url: app_api,
-    });
-    temp = temp.data;
-    const auth_code = temp.substring(temp.lastIndexOf());
-    //console.log("auth_token----\n", auth_code);
-    // console.log("what is code ", auth_code);
-    return auth_code;
-  }
-
-  async getApi() {
-    let token;
-    try {
-      token = await this.getToken();
-    } catch {
-      throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
+  async parseApi(Repo, api42s) {
+    const api = new UserLearningData();
+    let api_tuple;
+    for (const api42 of api42s) {
+      console.log(api42);
+      //api.intra_no = api42.id;
+      api.circle = api42.circle;
+      api.level = api42.level;
+      api.coalition_score = api42.coalition_score;
+      api.out_circle = api42.out_circle;
+      api.out_circle_date = api42.out_circle_date;
+      api.fk_user_no = api42.intra_no;
+      api_tuple = await Repo.create(api);
+      await Repo.save(api_tuple);
     }
-    return await this.requestApi(token);
+    return 'finish';
   }
 
-  // //: Observable<AxiosResponse<any>>
-  //     async getUserById(intra_id: String) {
-  //         let axios = require('axios');
+  /////////////////////////////////////////////////////////////
+  /////////////////////////end get api/////////////////////////
+  /////////////////////////////////////////////////////////////
 
-  //         let jsonData: string;
-  //         let OneRow;
-  //         let arr;
-  //         let rawData: string;
-  //         await axios.get("https://api.intra.42.fr/oauth/authorize?client_id=ea2e165515d03c90ddf5c01765248fa934fcbe34322b8b1c7dadac5628202128&redirect_uri=http%3A%2F%2Flocalhost&response_type=code"
-  //         ).then(function(response) {
-  //             rawData = response.data;
-  //          }).catch(function (err){
-  //          console.log(err); // 에러 처리 내용
-  //         });
-  //         return rawData;
-  //         console.log("response", response.json.toString);
-  //       //  console.log("rawdata",rawData);
-  //       //  return this.apiService.get();
-  //     }
+  // async showBrowser() {
+  //   return console.log('hi');
+  // }
+
+  // async getToken() {
+  //   let temp;
+
+  //   temp = await axios({
+  //     method: 'post', // 요청 방식
+  //     url: 'https://api.intra.42.fr/oauth/token',
+  //     data: {
+  //       grant_type: 'client_credentials',
+  //       client_id: app_id,
+  //       client_secret: app_secret,
+  //       redirect_uri: 'localhost:3000',
+  //     },
+  //   });
+  //   //console.log("\n----------temp---------------\n", temp.data);
+  //   temp = temp.data;
+  //   //  console.log("\n---------what is toke------------\n",temp.access_token);
+  //   return temp.access_token;
+  // }
+
+  // async requestApi(token) {
+  //   let temp;
+  //   const auth_token = this.getCode();
+  //   const page_num = 1;
+
+  //   //  console.log("인풋인자: token", token)
+  //   //  temp = token.get("https://api.intra.42.fr/v2/cursus_users").parsed;
+  //   // while(page < 3) {
+  //   temp = await axios({
+  //     method: 'get', // 요청 방식
+  //     //url: "https://api.intra.42.fr/v2/users/junghan",
+  //     //url: "https://api.intra.42.fr/v2/coalitions/124/users",
+  //     //url: "https://api.intra.42.fr/v2/users/junghan/locations_stats",
+  //     //url: "https://api.intra.42.fr/v2/dashes/124/users",
+  //     // url: "https://api.intra.42.fr/v2/events/124/users",
+  //     // url: "https://api.intra.42.fr/v2/accreditations/1/users",
+  //     //url: "https://api.intra.42.fr/v2/projects/8/users",
+  //     //url: "https://api.intra.42.fr/v2/cursus_users/graph/on/created_at/by/month", //cursus유저 생긴 수 확인하는 듯
+  //     url: `https://api.intra.42.fr/v2/cursus/21/cursus_users?filter[campus_id]=29&page[number]=${page_num}&page[size]=100`,
+  //     //url: `https://api.intra.42.fr/v2/cursus_users/?filter[campus_id]=29&page[number]=${page_num}&page[size]=100`,
+
+  //     headers: {
+  //       Authorization: `Bearer ${token}`,
+  //     },
+  //   });
+  //   // console.log(temp);
+  //   temp = temp.data;
+
+  //   // console.log(temp);
+  //   //  page++;
+  //   //   }
+  //   //console.log("what is api",temp);
+  //   //return temp;
+  //   // console.log("grade: ",temp[0]);
+  //   return temp;
+  // }
+
+  // // async inputApiInDb(api_dto) {
+  // //   const api = new Api();
+  // //   api.level = api_dto.level;
+  // //   api.email = api_dto.email;
+  // //   api.phone = api_dto.phone;
+  // //   api.circle = api_dto.level;
+  // //   api.outercircle = api_dto.outercircle;
+  // //   api.outercircle_date = api_dto.outercircle_date;
+  // //   api.coaltion_score = api_dto.coaltion_score;
+  // //   api.blackhole_time = api_dto.blackhole_time;
+  // //   api.remaining_period = api_dto.remaining_period;
+  // //   console.log(api);
+  // //   await this.apiRepository.save(api);
+  // // }
+
+  // parsingDate(date): string {
+  //   let parsed_date: string;
+
+  //   if (date === null) {
+  //     parsed_date = '9999-12-31';
+  //     return parsed_date;
+  //   }
+  //   const date_temp = new Date(date);
+  //   // let year = date_temp.getUTCFullYear;
+  //   parsed_date = `${`${date_temp.getFullYear()}-${
+  //     date_temp.getMonth() + 1
+  //   }-${date_temp.getDate()}`}`;
+  //   // console.log(parsed_date);
+  //   return parsed_date;
+  // }
+
+  // calculateDate(date) {
+  //   let calculated_date;
+
+  //   const today = new Date();
+
+  //   if (date === null) {
+  //     calculated_date = '9999';
+  //     return calculated_date;
+  //   }
+  //   const date_temp = new Date(date);
+  //   // console.log(today.getUTCMonth());
+  //   calculated_date = date_temp.getTime() - today.getTime();
+  //   const second = calculated_date / 1000;
+  //   const minute = second / 60;
+  //   const hour = minute / 60;
+  //   const day = hour / 24;
+  //   calculated_date = Math.floor(day); //소수점 버리는 것
+
+  //   // let year_to_day = (today.getUTCFullYear() - date_temp.getUTCFullYear()) * 365;
+  //   // let month_to_day = (today.getUTCFullYear() - date_temp.getUTCFullYear()) * ;
+  //   //    calculated_date = ((today.getUTCFullYear() - date_temp.getUTCFullYear()) * 365) + (today.getUTCFullYear() - date_temp.getUTCFullYear());
+  //   return calculated_date;
+  // }
+
+  // async parsingJson(api_data) {
+  //   const parsed_data = [];
+  //   const createApiDto = new CreateApiDto();
+
+  //   //   console.log(black);
+  //   //while(api_value[i] !== null){
+  //   for (const row in api_data) {
+  //     createApiDto['level'] = api_data[row].level;
+  //     createApiDto['email'] = api_data[row].user.email;
+  //     createApiDto['phone'] = api_data[row].user.phone;
+  //     createApiDto['circle'] = 9999;
+  //     createApiDto['out_circle'] = api_data[row].grade;
+  //     createApiDto['out_circle_date'] = '9999-12-31';
+  //     createApiDto['coalition_score'] = 0;
+  //     createApiDto['blackhole_time'] = await this.parsingDate(
+  //       api_data[row].blackholed_at,
+  //     );
+  //     createApiDto['remaining_period'] = await this.calculateDate(
+  //       api_data[row].blackholed_at,
+  //     );
+  //     console.log(createApiDto);
+  //     //   parsed_data[row] = await this.inputApiInDb(createApiDto);
+  //   }
+  //   //   parsed_data[row] = {};
+  //   //   parsed_data[row]['level'] = api_data[row].level;
+  //   //   parsed_data[row]['email'] = api_data[row].user.email;
+  //   //   parsed_data[row]['phone'] = api_data[row].user.phone;
+  //   //   parsed_data[row]['circle'] = 9999;
+  //   //   parsed_data[row]['outercircle'] = api_data[row].grade;
+  //   //   parsed_data[row]['outercircle_date'] = '9999-12-31';
+  //   //   parsed_data[row]['coaltion_score'] = 0;
+  //   //   parsed_data[row]['blackhole_date'] = await this.parsingDate(
+  //   //     api_data[row].blackholed_at,
+  //   //   );
+  //   //   parsed_data[row]['blackhole_remain_date'] = await this.calculateDate(
+  //   //     api_data[row].blackholed_at,
+  //   //   );
+  //   // }
+  //   //console.log(temp[2].blackhole_remain_date);
+  //   //console.log(api_json);
+  //   //   let today = new Date();
+  //   //  console.log(today);
+  //   //   console.log(`${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}`); //년과 일은 현지 시간대로 나타나지만 월같은 경우 0부터 시작, 요일도 0부터 시작
+  //   // console.log(temp[1]['blackhole_date']);
+  //   return parsed_data;
+  // }
+
+  // async getCode(): Promise<string> {
+  //   let temp;
+
+  //   temp = await axios({
+  //     method: 'get', // 요청 방식
+  //     url: app_api,
+  //   });
+  //   temp = temp.data;
+  //   const auth_code = temp.substring(temp.lastIndexOf());
+  //   //console.log("auth_token----\n", auth_code);
+  //   // console.log("what is code ", auth_code);
+  //   return auth_code;
+  // }
+
+  // async getApi() {
+  //   let token;
+  //   let api_data;
+  //   let parsed_data;
+  //   let response;
+  //   try {
+  //     token = await this.getToken();
+  //     api_data = await this.requestApi(token);
+  //     await this.parsingJson(api_data);
+  //   } catch {
+  //     throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
+  //   }
+
+  //   return new Promise<string>(() => 'finish');
+  // }
+
+  // // //: Observable<AxiosResponse<any>>
+  // //     async getUserById(intra_id: String) {
+  // //         let axios = require('axios');
+
+  // //         let jsonData: string;
+  // //         let OneRow;
+  // //         let arr;
+  // //         let rawData: string;
+  // //         await axios.get("https://api.intra.42.fr/oauth/authorize?client_id=ea2e165515d03c90ddf5c01765248fa934fcbe34322b8b1c7dadac5628202128&redirect_uri=http%3A%2F%2Flocalhost&response_type=code"
+  // //         ).then(function(response) {
+  // //             rawData = response.data;
+  // //          }).catch(function (err){
+  // //          console.log(err); // 에러 처리 내용
+  // //         });
+  // //         return rawData;
+  // //         console.log("response", response.json.toString);
+  // //       //  console.log("rawdata",rawData);
+  // //       //  return this.apiService.get();
+  // //     }
 }

--- a/packages/server/src/api/dto/create-api.dto.ts
+++ b/packages/server/src/api/dto/create-api.dto.ts
@@ -1,0 +1,30 @@
+//import { IsNotEmpty } from 'class-validator';
+
+export class CreateApiDto {
+  //  @IsNotEmpty()
+  level: number;
+
+  // @IsNotEmpty()
+  email: string;
+
+  //  @IsNotEmpty()
+  phone: string;
+
+  // @IsNotEmpty()
+  circle: number;
+
+  //  @IsNotEmpty()
+  outercircle: string;
+
+  //  @IsNotEmpty()
+  outercircle_date: Date;
+
+  //  @IsNotEmpty()
+  coaltion_score: number;
+
+  //  @IsNotEmpty()
+  blackhole_time: Date;
+
+  //  @IsNotEmpty()
+  remaining_period: number;
+}

--- a/packages/server/src/api/entity/api.entity.ts
+++ b/packages/server/src/api/entity/api.entity.ts
@@ -1,0 +1,35 @@
+import { ObjectType, Field, Int, Float } from '@nestjs/graphql';
+
+//안씀
+@ObjectType()
+export class Api {
+  @Field(() => Int)
+  intra_no: number;
+
+  @Field(() => Float)
+  level: number;
+
+  @Field(() => Int)
+  email: string;
+
+  @Field(() => Int)
+  phone: string;
+
+  @Field(() => Int)
+  circle: number;
+
+  @Field(() => Int)
+  outercircle: string;
+
+  @Field(() => Int)
+  outercircle_date: Date;
+
+  @Field(() => Int)
+  coaltion_score: number;
+
+  @Field(() => Int)
+  blackhole_time: Date;
+
+  @Field(() => Int)
+  remaining_period: number;
+}

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -158,9 +158,11 @@ type UserLapiscineInformation {
 }
 
 type UserLearningData {
+  circle: Float
   coalition_score: Float!
   created_date: DateTime!
-  out_circle: String!
+  level: Float!
+  out_circle: String
   out_circle_date: DateTime
   pk: Float!
 }

--- a/packages/server/src/updater/name_types/updater.name.ts
+++ b/packages/server/src/updater/name_types/updater.name.ts
@@ -17,6 +17,8 @@ export const mapObj = [
     { spName: '성별', dbName: 'gender' },
     { spName: '생년월일', dbName: 'birthday' },
     { spName: '만 나이', dbName: 'grade' }, //테이블에 없음
+    { spName: '전화번호', dbName: 'phone_number' },
+    { spName: '이메일', dbName: 'email' },
     //이메일, 전화번호는 api
   ],
   [
@@ -32,8 +34,10 @@ export const mapObj = [
     { spName: '사유', dbName: 'absence_reason' },
   ],
   [
+    { spName: '잔여기간', dbName: 'remaining_period' },
+    { spName: '블랙홀일자', dbName: 'blackhole_date' },
     { spName: '블랙홀 사유', dbName: 'reason_of_blackhole' },
-    //잔여기간, 블랙홀일자는 api
+    //잔여기간, 블랙홀일자는 api -> 추가함
   ],
   [
     { spName: '과정중단 과정중단일자', dbName: 'date_of_break' },
@@ -113,3 +117,5 @@ export const endOfTable = [
   '지원금산정 지원금수령여부',
   '출입카드정보 사진이미지파일',
 ];
+
+export const apiOfTable = ['학습데이터'];

--- a/packages/server/src/updater/updater.module.ts
+++ b/packages/server/src/updater/updater.module.ts
@@ -25,6 +25,7 @@ import {
   UserReasonOfBreak,
 } from 'src/user_status/entity/user_status.entity';
 import { UpdaterController } from './updater.controller';
+import { ApiService } from 'src/api/api.service';
 
 @Module({
   imports: [
@@ -48,6 +49,6 @@ import { UpdaterController } from './updater.controller';
     ]),
   ],
   controllers: [UpdaterController],
-  providers: [UpdaterResolver, UpdaterService],
+  providers: [UpdaterResolver, UpdaterService, ApiService],
 })
 export class UpdaterModule {}

--- a/packages/server/src/updater/updater.service.ts
+++ b/packages/server/src/updater/updater.service.ts
@@ -1,6 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { SHEET_ID2, SPREAD_END_POINT } from 'src/config/key';
+import axios from 'axios';
+import { ApiService } from 'src/api/api.service';
+import { CreateApiDto } from 'src/api/dto/create-api.dto';
+import { Api } from 'src/api/entity/api.entity';
+import {
+  app_id,
+  app_secret,
+  SHEET_ID2,
+  SPREAD_END_POINT,
+} from 'src/config/key';
 import { UserAccessCardInformation } from 'src/user_information/entity/user_access_card_information.entity';
 import { User } from 'src/user_information/entity/user_information.entity';
 import { UserOtherInformation } from 'src/user_information/entity/user_other_information.entity';
@@ -24,7 +33,7 @@ import {
   UserReasonOfBreak,
 } from 'src/user_status/entity/user_status.entity';
 import { Repository } from 'typeorm';
-import { endOfTable, mapObj } from './name_types/updater.name';
+import { apiOfTable, endOfTable, mapObj } from './name_types/updater.name';
 
 @Injectable() //총 16개의 테이블
 export class UpdaterService {
@@ -61,6 +70,7 @@ export class UpdaterService {
     private userReasonOfBreak: Repository<UserReasonOfBreak>,
     @InjectRepository(UserLapiscineInformation)
     private userLapiscineInformation: Repository<UserLapiscineInformation>,
+    private apiService: ApiService,
   ) {}
 
   async getAllSpread(): Promise<string> {
@@ -78,6 +88,7 @@ export class UpdaterService {
       this.userLeaveOfAbsence,
       this.userBlackhole,
       this.userReasonOfBreak,
+
       this.userOtherRepository,
       this.userLapiscineInformation,
       this.userEmploymentAndFound,
@@ -86,6 +97,8 @@ export class UpdaterService {
       this.userComputationFund,
       this.userAccessCardRepository,
     ];
+
+    const apiOfRepo = [this.userLearningData];
 
     await axios({
       method: 'get',
@@ -106,22 +119,36 @@ export class UpdaterService {
       });
     // eslint-disable-next-line prefer-const
     jsonData = spreadData;
-
+    //console.log(jsonData, 'jsonData');
     const obj = JSON.parse(jsonData);
     const cols = obj.table.cols;
     const rows = obj.table.rows;
+    const api42s = await this.apiService.getApi();
+
+    //console.log(api42s, 'wht');
+    //return api42s;
 
     for (const col in cols) {
+      console.log(col, 'col', tableNum, 'table');
       if (cols[col]['label'] === endOfTable[tableNum])
-        index = this.parseSpread(
+        //tablle num 을 추가시키면서 label과 같은지 찾기, endoftable과 clos의 수가 같아서 가능
+        index = await this.parseSpread(
           cols,
           rows,
           index,
           repoArray[tableNum],
           mapObj[tableNum],
           endOfTable[++tableNum],
+          api42s,
         );
+      //console.log("table nun" , tableNum);
     }
+    for (const api_table in apiOfTable) {
+      if (apiOfTable[api_table] == '학습데이터') {
+        await this.apiService.parseApi(apiOfRepo[api_table], api42s);
+      }
+    }
+
     return await 'finish';
   }
 
@@ -140,27 +167,29 @@ export class UpdaterService {
     return year + '-' + month + '-' + day;
   }
 
-  parseSpread(
+  async parseSpread(
     cols,
     rows,
     colIdx: number,
     Repo,
     mapObj,
     endOfTable: string,
-  ): number {
+    api42s,
+  ): Promise<number> {
     let tupleLine;
     let idx; //특정 테이블에 있는 컬럼인지 검사하는 색인
     let jdx = colIdx; //컬럼의 위치 튜플의 도메인 위치 맞춰주기 위한 색인
-
+    //console.log(rows, 'rowss');
     for (const row of rows) {
       const tuple = {};
       jdx = colIdx; //특정 테이블의 시작에 해당하는 컬럼의 색인으로 초기화
       while (1) {
-        //하나의 로우 완성
-        idx = 0;
-        if (cols[jdx] === undefined || cols[jdx]['label'] === endOfTable) break;
-        else if (row['c'][jdx] === null) {
+        if (cols[jdx] === undefined || cols[jdx]['label'] === endOfTable) {
+          console.log('breaked-----');
+          break;
+        } else if (row['c'][jdx] === null) {
           tuple[`${cols[jdx]['label']}`] = null; //셀값이 null인 경우 별도의 처리
+          console.log(tuple[`${cols[jdx]['label']}`], 'null?');
         } else if (
           (idx = this.compareColumn(cols[jdx]['label'], mapObj)) !== -1
         ) {
@@ -171,12 +200,29 @@ export class UpdaterService {
             );
           else if (row['c'][jdx]['v'] !== null)
             tuple[`${mapObj[idx].dbName}`] = row['c'][jdx]['v'];
+          console.log(
+            tuple[`${mapObj[idx].dbName}`],
+            ` : ${mapObj[idx].dbName}`,
+          );
         }
         jdx++;
       }
+      //console.log('before intra', tuple, '111111111111');
+      const api42 = await this.apiService.getTupleFromApi(
+        //updater name이 13개 유효하므로, 총 13번 호출됨, email, phone 같은 건 해당 테이블일 때만 컬럼에 넣어주면 될듯
+        row['c'][1]['f'],
+        api42s,
+      );
+      //console.log(api42);
+      tuple['email'] = api42.email;
+      tuple['phone_number'] = api42.phone_number;
+      tuple['remaining_period'] = api42.remaining_period;
+      tuple['blackhole_time'] = api42.blackhole_time;
+      //tuple['circle'] = api42.circle;
+      console.log(tuple, 'tupleeee');
       tupleLine = Repo.create(tuple);
       tupleLine['fk_user_no'] = row['c'][1]['f'];
-      Repo.save(tupleLine);
+      await Repo.save(tupleLine);
     }
     return jdx;
   }

--- a/packages/server/src/user_information/user_information.module.ts
+++ b/packages/server/src/user_information/user_information.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { UserInformationController } from './user_information.controller';
 import { UserInformationService } from './user_information.service';
 import { UserInformationResolver } from './user_information.resolver';
@@ -11,6 +11,7 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { JoinedTable } from './argstype/joinedTable';
 import { Filter } from './filter';
 import { DataSource } from 'typeorm';
+import { AppModule } from 'src/app.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { DataSource } from 'typeorm';
       UserPersonalInformation,
       UserOtherInformation,
       UserAccessCardInformation,
+      //AppModule,
       DataSource,
     ]),
   ],

--- a/packages/server/src/user_information/user_information.service.spec.ts
+++ b/packages/server/src/user_information/user_information.service.spec.ts
@@ -1,7 +1,17 @@
 import { last } from 'rxjs';
 import { UserBlackhole } from 'src/user_status/entity/user_status.entity';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { createMemDB } from '../utils/testing-helpers/createMemDB';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import {
+  getDataSourceToken,
+  getRepositoryToken,
+  InjectDataSource,
+} from '@nestjs/typeorm';
+
+import { DataSource, LessThan } from 'typeorm';
+import { UserAccessCardInformation } from './entity/user_access_card_information.entity';
 import { User } from './entity/user_information.entity';
 import { UserPersonalInformation } from './entity/user_personal_information.entity';
 import { UserInformationService } from './user_information.service';
@@ -194,4 +204,5 @@ describe('User Service', () => {
     expect(await userService.getNumOfPeopleByFilter(filters)).not.toBeNull();
     expect(await userService.getNumOfPeopleByFilter(filters)).toBe(2);
   });
+  it.todo('findByUserStatus은 반드시 ~~~을 return 해야합니다.');
 });

--- a/packages/server/src/user_information/user_information.service.ts
+++ b/packages/server/src/user_information/user_information.service.ts
@@ -460,6 +460,7 @@ export class UserInformationService {
     // test['take'] = {
     //   userProcessProgress:1,
     // }; <- 안되는걸로 결론
+
     const ret = await this.dataSource.getRepository(User).find(test);
     await queryRunner.release();
     return ret;

--- a/packages/server/src/user_status/entity/user_status.entity.ts
+++ b/packages/server/src/user_status/entity/user_status.entity.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from '@nestjs/graphql';
+import { Field, Float, ObjectType } from '@nestjs/graphql';
 import {
   BaseEntity,
   Column,
@@ -21,12 +21,25 @@ export class UserLearningData extends BaseEntity {
   @PrimaryGeneratedColumn({ name: 'pk' })
   pk: number;
 
+  @Field({ nullable: true, defaultValue: 0 }) //특정 데이터 때문에 널 허용중
+  @Column({ name: 'circle', nullable: true, default: 0 })
+  circle: number;
+
+  @Field({ nullable: false, defaultValue: 0 })
+  @Column({
+    type: 'float',
+    name: 'level',
+    nullable: false,
+    default: 0,
+  })
+  level: number;
+
   @Field({ nullable: false, defaultValue: 0 })
   @Column({ name: 'coalition_score', nullable: false, default: 0 })
   coalition_score: number;
 
-  @Field({ nullable: false, defaultValue: 'N' })
-  @Column({ name: 'out_circle', nullable: false, default: 'N' })
+  @Field({ nullable: true, defaultValue: 'N' }) //특정 데이터 때문에 널 허용중
+  @Column({ name: 'out_circle', nullable: true, default: 'N' })
   out_circle: string;
 
   @Field({ nullable: true })
@@ -205,7 +218,7 @@ export class UserReasonOfBreak extends BaseEntity {
   created_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
-  fk_user_no: string;
+  fk_user_no: number;
 
   @ManyToOne(() => User, (user) => user.userReasonOfBreak)
   @JoinColumn({ name: 'fk_user_no' })


### PR DESCRIPTION
updater에서 스프레드를 받아오는 로직 이후에 api를 받아오는 로직 추가

"feat #55", "docs #107"

### 작업 동기 (Motivation)
 update 모듈로 42api를 요청하여 값을 받아와 DB에 저장하고자 함
### 변경 사항 요약 (Key changes)
- api 모듈 추가
- 구글 스프레드 시트에서 받아오는 데이터중 api 가 필요한 데이터들을 채워서 db에 저장
- api데이터로만 구성된 DB테이블에 데이터 저장

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부
<img width="942" alt="스크린샷 2022-07-06 오후 3 59 09" src="https://user-images.githubusercontent.com/50915710/177488843-858ed1cb-670f-4783-a8b5-2ce0abfbef84.png">

### 리뷰어들에게 요청사항
- 아직 circle값과 coalition_score값 , phone 값을 받아오지 못하고 있습니다.
- phone의 경우 보안및 권한이 필요한 부분이고, circle과 coalition_score의 경우 api end-point를 찾지 못하였습니다.
- 추후에 받아올 수 있도록 하겠습니다.
