### PR TITLE
feat(server): 관리자를 위한 graphql api 추가

### DIFF
--- a/packages/server/src/auth/auth.module.ts
+++ b/packages/server/src/auth/auth.module.ts
@@ -1,13 +1,16 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { SECRETORKEY } from 'src/config/42oauth';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { Bocal } from './entity/bocal.entity';
 import { JwtStrategy } from './jwt.strategy';
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([Bocal]),
     PassportModule.register({ defaultStrategy: 'jwt' }), //기억해두기
     JwtModule.register({
       secret: SECRETORKEY,

--- a/packages/server/src/auth/auth.service.ts
+++ b/packages/server/src/auth/auth.service.ts
@@ -7,6 +7,7 @@ import { join } from 'path';
 import { AUTHPARAM } from 'src/config/42oauth';
 import { jsonToFile } from 'src/utils/json-helper/jsonHelper';
 import { DataSource } from 'typeorm';
+import { Bocal, BocalRole } from './entity/bocal.entity';
 
 @Injectable()
 export class AuthService {
@@ -15,9 +16,18 @@ export class AuthService {
     private jwtService: JwtService,
   ) {}
 
+  /**
+   * 배포할때 수정필요함
+   */
   async createJwt(obj) {
     // 아래 if문은 주석문은 배포할때 주석풀어주기
     // if (obj['staff'] == false) throw new BadRequestException();
+    const bocal = this.dataSource.getRepository(Bocal).create();
+    bocal.id = obj.id;
+    bocal.login = obj.login;
+    bocal.role = BocalRole.ADMIN; //이 부분 나중에 분기문으로 처리
+    bocal.staff = true;
+    await this.dataSource.getRepository(Bocal).save(bocal);
     const payload = obj;
     console.log(payload);
     const access_token = await this.jwtService.sign(payload);
@@ -53,13 +63,7 @@ export class AuthService {
           Authorization: `Bearer ${access_token}`,
         },
       });
-      // console.log(response42.data);
-      //이제 jwt 토큰 생성 및 jwt passport 그리고 guard 설정
     }
-    // jsonToFile(
-    //   join(process.cwd(), './src/auth/responseJson.Json'),
-    //   response42.data,
-    // );
     // 아래에서 id는 고유 number임 ("huchoi"같은 intra_id가 아님)
     const payload = {
       id: response42.data.id,

--- a/packages/server/src/auth/entity/bocal.entity.ts
+++ b/packages/server/src/auth/entity/bocal.entity.ts
@@ -1,0 +1,33 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+export enum BocalRole {
+  MASTER = 'master',
+  ADMIN = 'admin', // read, write 제한 없이 가능
+  VIEWER = 'viewer', // read 제한 없이 가능
+  GUEST = 'guest', // 일부분 read만 가능
+  // 더 추가할 ROLE이 있을지 생각해보기
+}
+
+@Entity()
+export class Bocal {
+  @PrimaryColumn({ name: 'id' })
+  id: number;
+
+  @Column({ name: 'login', nullable: false })
+  login: string;
+
+  @Column({ name: 'staff', nullable: false })
+  staff: boolean; //의미 없는 컬럼일수도...?
+
+  /**
+   * api에서 오는 스태프 정보중에서 식별정보가 무엇무엇이 있는지 알아내서 column 추가하기
+   */
+
+  @Column({
+    type: 'enum',
+    enum: BocalRole,
+    default: BocalRole.GUEST,
+    nullable: false,
+  }) //도메인 제한 확인(도메인 아닌거 넣으면 pg에서 에러발생하는거 확인)
+  role: BocalRole;
+}

--- a/packages/server/src/auth/jwt.strategy.ts
+++ b/packages/server/src/auth/jwt.strategy.ts
@@ -5,6 +5,7 @@ import { userInfo } from 'os';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { SECRETORKEY } from 'src/config/42oauth';
 import { DataSource } from 'typeorm';
+import { Bocal } from './entity/bocal.entity';
 
 const cookieExtractor = function (req) {
   let token: string = null;
@@ -40,7 +41,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validateUser(payload) {
     //DB에서 해당 사용자에 대한 정보가 있는지 체크 <- repo.findOne()하면 될듯?
-    if (payload) return payload;
+    const user = this.dataSource.getRepository(Bocal).findOne(payload);
+    if (user) return payload;
     else return null;
   }
 }

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -24,7 +24,7 @@ type JoinedTable {
   intra_no: Int!
   name: String
   start_process: DateTime
-  userAccessCardInformation: UserAccessCardInformation
+  userAccessCardInformation: [UserAccessCardInformation!]
   userBlackhole: [UserBlackhole!]
   userComputationFund: [UserComputationFund!]
   userEducationFundState: [UserEducationFundState!]
@@ -36,18 +36,25 @@ type JoinedTable {
   userLearningData: [UserLearningData!]
   userLeaveOfAbsence: [UserLeaveOfAbsence!]
   userOtherInformation: [UserOtherInformation!]
-  userPersonalInformation: UserPersonalInformation
+  userPersonalInformation: [UserPersonalInformation!]
   userProcessProgress: [UserProcessProgress!]
   userReasonOfBreak: [UserReasonOfBreak!]
 }
 
+type Mutation {
+  deleteUserInformation(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
+  recoverUserInformaiton(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
+  softDeleteRemoveWithdrawTest(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): [JoinedTable!]!
+  updateUserInformation(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
+}
+
 type Query {
   getAllSpread: String!
-  getNumOfPeopleByFilter(filters: [Filter!]!): Int!
-  getPeopleByFilter(filters: [Filter!]!): [JoinedTable!]!
+  getNumOfPeopleByFilter(filters: [Filter!]!, skip: Int, take: Int): Int!
+  getPeopleByFilter(filters: [Filter!]!, skip: Int, take: Int): [JoinedTable!]!
+  getPeopleByFilterForAdmin(filters: [Filter!]!, skip: Int, take: Int): [JoinedTable!]!
   getUserAccessCardInformation: [UserAccessCardInformation!]!
   getUserBlackhole: [UserBlackhole!]!
-  getUserById: [User!]!
   getUserComputationFund: [UserComputationFund!]!
   getUserEmploymentAndFound: [UserEmploymentAndFound!]!
   getUserEmploymentStatus: [UserEmploymentStatus!]!
@@ -59,17 +66,7 @@ type Query {
   getUserPersonalInformation: [UserPersonalInformation!]!
   getUserProcessProgress: [UserProcessProgress!]!
   getUserReasonOfBreak: UserReasonOfBreak!
-  getUsers(column: String!, entityName: String!, givenValue: String!, latest: Boolean!, operator: String!): [User!]!
-}
-
-type User {
-  academic_state: String!
-  coalition: String!
-  created_date: DateTime!
-  grade: String!
-  intra_id: String!
-  intra_no: Int!
-  name: String!
+  tempFunction: [JoinedTable!]!
 }
 
 type UserAccessCardInformation {
@@ -190,6 +187,7 @@ type UserOtherInformation {
 type UserPersonalInformation {
   birthday: String!
   created_date: DateTime!
+  deleted_date: DateTime!
   email: String!
   gender: String!
   phone_number: String!

--- a/packages/server/src/user_information/argstype/cudDto.argstype.ts
+++ b/packages/server/src/user_information/argstype/cudDto.argstype.ts
@@ -1,0 +1,19 @@
+import { ArgsType, Field, Int } from '@nestjs/graphql';
+
+@ArgsType()
+export class CudDto {
+  @Field((type) => Int)
+  intra_no: number;
+
+  @Field()
+  entityName: string;
+
+  @Field((type) => Int)
+  pk: number;
+
+  @Field()
+  column: string;
+
+  @Field()
+  value: string;
+}

--- a/packages/server/src/user_information/argstype/filter.argstype.ts
+++ b/packages/server/src/user_information/argstype/filter.argstype.ts
@@ -9,4 +9,8 @@ export class FilterArgs {
 
   @Field((type) => [Filter]) //에러발생 -> Filter 선언부쪽에 @InputType()붙여주니까 해결됨
   filters: Filter[];
+  @Field((type) => Int, { nullable: true })
+  take: number;
+  @Field((type) => Int, { nullable: true })
+  skip: number;
 }

--- a/packages/server/src/user_information/argstype/joinedTable.ts
+++ b/packages/server/src/user_information/argstype/joinedTable.ts
@@ -49,11 +49,11 @@ export class JoinedTable {
   @Field((type) => [UserOtherInformation], { nullable: true })
   userOtherInformation: UserOtherInformation[];
 
-  @Field((type) => UserPersonalInformation, { nullable: true })
-  userPersonalInformation: UserPersonalInformation; //일대일 이니까
+  @Field((type) => [UserPersonalInformation], { nullable: true })
+  userPersonalInformation: UserPersonalInformation[]; //일대일 이니까 -> DB에서는 그럴지몰라도 반환값에서는 배열로반환
 
-  @Field((type) => UserAccessCardInformation, { nullable: true })
-  userAccessCardInformation: UserAccessCardInformation; //일대일 이니까
+  @Field((type) => [UserAccessCardInformation], { nullable: true })
+  userAccessCardInformation: UserAccessCardInformation[]; //일대일 이니까 -> DB에서는 그럴지몰라도 반환값에서는 배열로반환
 
   @Field((type) => [UserEmploymentAndFound], { nullable: true })
   userEmploymentAndFound: UserEmploymentAndFound[];

--- a/packages/server/src/user_information/entity/user_access_card_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_access_card_information.entity.ts
@@ -3,6 +3,7 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   OneToOne,
@@ -45,8 +46,12 @@ export class UserAccessCardInformation extends BaseEntity {
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
-  fk_user_no: string;
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
+
+  // @Column({ name: 'fk_user_no', nullable: true })
+  // fk_user_no: string;
 
   @OneToOne(() => User, (user) => user.userAccessCardInformation, {
     createForeignKeyConstraints: false, //외래키 제약조건 해제

--- a/packages/server/src/user_information/entity/user_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_information.entity.ts
@@ -2,7 +2,9 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
+  JoinColumn,
   JoinTable,
   ManyToOne,
   OneToMany,
@@ -74,6 +76,10 @@ export class User {
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
 
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
+
   // @Field()
   // vailidated_date;
 
@@ -88,7 +94,7 @@ export class User {
   @OneToOne(
     () => UserPersonalInformation,
     (userPersonalInformation) => userPersonalInformation.user,
-    { cascade: true, eager: true },
+    { cascade: true },
   )
   userPersonalInformation: UserPersonalInformation;
 
@@ -96,6 +102,7 @@ export class User {
   @OneToOne(
     () => UserAccessCardInformation,
     (userAccessCardInformation) => userAccessCardInformation.user,
+    { cascade: true },
   )
   userAccessCardInformation: UserAccessCardInformation;
 
@@ -103,6 +110,7 @@ export class User {
   @OneToMany(
     () => UserOtherInformation,
     (userOtherInformation) => userOtherInformation.user,
+    { cascade: true },
   )
   userOtherInformation: UserOtherInformation[];
 
@@ -114,6 +122,7 @@ export class User {
   @OneToMany(
     () => UserLearningData,
     (userLearningDate) => userLearningDate.user,
+    { cascade: true },
   )
   userLearningDate: UserLearningData[];
 
@@ -121,17 +130,21 @@ export class User {
   @OneToMany(
     () => UserProcessProgress,
     (userProcessProgress) => userProcessProgress.user,
+    { cascade: true },
   )
   userProcessProgress: UserProcessProgress[];
 
   // @Field((type) => [UserBlackhole])
-  @OneToMany(() => UserBlackhole, (userBlackhole) => userBlackhole.user)
+  @OneToMany(() => UserBlackhole, (userBlackhole) => userBlackhole.user, {
+    cascade: true,
+  })
   userBlackhole: UserBlackhole[];
 
   // @Field((type) => [UserLeaveOfAbsence])
   @OneToMany(
     () => UserLeaveOfAbsence,
     (userLeaveOfAbsence) => userLeaveOfAbsence.user,
+    { cascade: true },
   )
   userLeaveOfAbsence: UserLeaveOfAbsence[];
 
@@ -139,6 +152,7 @@ export class User {
   @OneToMany(
     () => UserReasonOfBreak,
     (userReasonOfBreak) => userReasonOfBreak.user,
+    { cascade: true },
   )
   userReasonOfBreak: UserReasonOfBreak[];
 
@@ -146,6 +160,7 @@ export class User {
   @OneToMany(
     () => UserLapiscineInformation,
     (userLapiscineInformation) => userLapiscineInformation.user,
+    { cascade: true },
   )
   userLapiscineInformation: UserLapiscineInformation[];
 
@@ -157,6 +172,7 @@ export class User {
   @OneToMany(
     () => UserComputationFund,
     (userComputationFund) => userComputationFund.user,
+    { cascade: true },
   )
   userComputationFund: UserComputationFund[];
 
@@ -164,6 +180,7 @@ export class User {
   @OneToMany(
     () => UserEducationFundState,
     (userEducationFundState) => userEducationFundState.user,
+    { cascade: true },
   )
   userEducationFundState: UserEducationFundState[];
 
@@ -175,6 +192,7 @@ export class User {
   @OneToMany(
     () => UserEmploymentAndFound,
     (UserEmploymentAndFound) => UserEmploymentAndFound.user,
+    { cascade: true },
   )
   userEmploymentAndFound: UserEmploymentAndFound[];
 
@@ -182,6 +200,7 @@ export class User {
   @OneToMany(
     () => UserInternStatus,
     (userInternStatus) => userInternStatus.user,
+    { cascade: true },
   )
   userInternStatus: UserInternStatus[];
 
@@ -189,6 +208,7 @@ export class User {
   @OneToMany(
     () => UserHrdNetUtilize,
     (userHrdNetUtilize) => userHrdNetUtilize.user,
+    { cascade: true },
   )
   userHrdNetUtilize: UserHrdNetUtilize[];
 
@@ -196,6 +216,7 @@ export class User {
   @OneToMany(
     () => UserEmploymentStatus,
     (userEmploymentStatus) => userEmploymentStatus.user,
+    { cascade: true },
   )
   userEmploymentStatus: UserEmploymentStatus[];
 }

--- a/packages/server/src/user_information/entity/user_other_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_other_information.entity.ts
@@ -3,6 +3,7 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   JoinTable,
@@ -46,6 +47,10 @@ export class UserOtherInformation extends BaseEntity {
   @Field()
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;

--- a/packages/server/src/user_information/entity/user_personal_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_personal_information.entity.ts
@@ -3,6 +3,7 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   OneToOne,
@@ -43,13 +44,15 @@ export class UserPersonalInformation {
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
-  fk_user_no: string; //외래키값을 선언하지 않으면 null으로 판단됨
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
+  // @Column({ name: 'fk_user_no', nullable: true })
+  // fk_user_no: string; //외래키값을 선언하지 않으면 null으로 판단됨
 
   @OneToOne(() => User, (user) => user.userPersonalInformation, {
     createForeignKeyConstraints: false, //외래키 제약조건 해제
   })
-  @JoinColumn({ name: 'fk_user_no' }) //user와 이름이 중복되는 에러로 인해 이름변경
-  // @PrimaryColumn({name: "user"})
+  @JoinColumn() //user와 이름이 중복되는 에러로 인해 이름변경
   user: User;
 }

--- a/packages/server/src/user_information/filter.ts
+++ b/packages/server/src/user_information/filter.ts
@@ -1,22 +1,17 @@
-import { ArgsType, Field, InputType, ObjectType } from '@nestjs/graphql';
+import { ArgsType, Field, InputType, Int, ObjectType } from '@nestjs/graphql';
 
 @ArgsType()
-@ObjectType({
-  description:
-    '아래 5개의 필드중에서 log 필드를 제외한 4개의 필드는 필수 입력값. log필드값을 true로 하면 최신정보 + 과거정보를 응답. log필드값을 false로 하면 최신정보만을 응답',
-})
+@ObjectType()
 @InputType()
 export class Filter {
   @Field()
   entityName: string;
-  @Field()
+  @Field({ nullable: true })
   column: string;
-  @Field()
+  @Field({ nullable: true })
   operator: string;
-  @Field()
-  givenValue: string; //이렇게 물음표 안붙으면 필수값이라는 뜻
-  @Field()
+  @Field({ nullable: true })
+  givenValue: string;
+  @Field({ nullable: true })
   latest: boolean;
-  // @Field()
-  // log?: boolean; //이렇게 물음표 붙이면 '필수값이 아니'라는 뜻
 }

--- a/packages/server/src/user_information/user_information.controller.ts
+++ b/packages/server/src/user_information/user_information.controller.ts
@@ -7,7 +7,7 @@ export class UserInformationController {
   constructor(private readonly userService: UserInformationService) {}
   @Get()
   testUser() {
-    return this.userService.querySampel();
+    return 'hello user!';
   }
   @Get('/temp')
   tempFunction(@Query() query) {

--- a/packages/server/src/user_information/user_information.module.ts
+++ b/packages/server/src/user_information/user_information.module.ts
@@ -20,7 +20,6 @@ import { AppModule } from 'src/app.module';
       UserPersonalInformation,
       UserOtherInformation,
       UserAccessCardInformation,
-      //AppModule,
       DataSource,
     ]),
   ],

--- a/packages/server/src/user_information/user_information.resolver.ts
+++ b/packages/server/src/user_information/user_information.resolver.ts
@@ -1,63 +1,91 @@
-import { Int, Query } from '@nestjs/graphql';
+import { Int, Mutation, Query } from '@nestjs/graphql';
 import { Args, Resolver } from '@nestjs/graphql';
 import { UserAccessCardInformation } from 'src/user_information/entity/user_access_card_information.entity';
 import { User } from 'src/user_information/entity/user_information.entity';
 import { UserOtherInformation } from 'src/user_information/entity/user_other_information.entity';
 import { UserPersonalInformation } from 'src/user_information/entity/user_personal_information.entity';
-import { QueryResult } from 'typeorm';
+import { DataSource, Not, QueryResult } from 'typeorm';
 import { FilterArgs } from './argstype/filter.argstype';
 import { GetUserOtherInformationArgs } from './argstype/userOtherInformation.argstype';
 import { Filter } from './filter';
 import { JoinedTable } from './argstype/joinedTable';
 import { UserInformationService } from './user_information.service';
+import { CudDto } from './argstype/cudDto.argstype';
+import { InjectDataSource } from '@nestjs/typeorm';
 
 @Resolver() //graphql에서 controler가 resolver
 export class UserInformationResolver {
   constructor(private readonly userService: UserInformationService) {}
 
-  @Query(() => [User])
-  getUsers(@Args() arg: Filter) {
-    return this.userService.querySampel();
-  }
-
-  @Query(() => [User])
-  getUserById() {
-    return this.userService.querySampel();
-  }
   @Query(() => [UserPersonalInformation])
   getUserPersonalInformation() {
     return this.userService.getUserPersonalInformation();
   }
 
+  @Query(() => [JoinedTable])
+  async tempFunction() {
+    return await this.tempFunction();
+  }
+
   @Query(() => [UserOtherInformation])
-  getUserOtherInformation(@Args() args: GetUserOtherInformationArgs) {
-    return this.userService.getUserOtherInformation();
+  async getUserOtherInformation(@Args() args: GetUserOtherInformationArgs) {
+    return await this.userService.getUserOtherInformation();
   }
 
   @Query(() => [UserAccessCardInformation])
-  getUserAccessCardInformation() {
-    return this.userService.getUserAccessCardInformation();
+  async getUserAccessCardInformation() {
+    return await this.userService.getUserAccessCardInformation();
   }
 
-  // @Query(() => [JoinedTable])
-  // getNumofPeopleByFilterBeforeJson(@Args() filterArg: FilterArgs) {
-  //   // console.log(filterArg);
-  //   // return;
-  //   return this.userService.processFilters(filterArg.filters['realFilters']);
-  // }
-
-  // @Query(() => [JoinedTable])
-  // getFilter(@Args() filterArg: Filter[]) {
-  //   return this.userService.processFilters(filterArg);
-  // }
-
   @Query(() => [JoinedTable])
-  getPeopleByFilter(@Args() filterArg: FilterArgs) {
-    return this.userService.getPeopleByFiter(filterArg.filters);
+  async getPeopleByFilter(@Args() filterArg: FilterArgs) {
+    return await this.userService.getPeopleByFiter(filterArg);
   }
 
   @Query(() => Int)
-  getNumOfPeopleByFilter(@Args() filterArg: FilterArgs) {
-    return this.userService.getNumOfPeopleByFilter(filterArg.filters);
+  async getNumOfPeopleByFilter(@Args() filterArg: FilterArgs) {
+    return await this.userService.getNumOfPeopleByFilter(filterArg);
+  }
+
+  //관리자를 위한 쿼리문
+  //나중에 가드설정할때 다른 컨트롤러와는 다른 가드설정해줘야함(role = MASTER || ADMIN 만 통과하게)
+  //아래 Mutation도 관리자 가드 설정해줘야함
+  @Query(() => [JoinedTable])
+  async getPeopleByFilterForAdmin(@Args() filterArgs: FilterArgs) {
+    return await this.userService.getPeopleByFilterForAdmin(filterArgs);
+  }
+
+  // [intra_no], [entityName, pk, column, value]
+  // pk 대신에 created_date를 주는게 나을수도?
+  @Mutation(() => Boolean)
+  async updateUserInformation(@Args() cudDto: CudDto) {
+    return this.userService.updateUserInformation(cudDto);
+  }
+
+  // [Filter 배열], [entityName, column, value]
+  // @Mutation(() => Boolean)
+  // updateManyUsersInformation() {}
+
+  // softDelete 사용할 예정
+  // [intra_no], [entityName, pk, column, value]
+  @Mutation(() => Boolean)
+  async deleteUserInformation(@Args() cudDto: CudDto) {
+    return await this.userService.deleteUserInformation(cudDto);
+  }
+
+  // softDelete 사용할 예정
+  // @Mutation(() => Boolean)
+  // deleteManyUsersInformation() {}
+
+  // softDelte 된 것을 recover
+  // [intra_no], [entityName, pk, column, value]
+  @Mutation(() => Boolean)
+  async recoverUserInformaiton(@Args() cudDto: CudDto) {
+    return await this.userService.recoverUserInformaiton(cudDto);
+  }
+
+  @Mutation(() => [JoinedTable])
+  async softDeleteRemoveWithdrawTest(@Args() cudDto: CudDto) {
+    return await this.userService.softDeleteRemoveWithdrawTest(cudDto);
   }
 }

--- a/packages/server/src/user_job/entity/user_job.entity.ts
+++ b/packages/server/src/user_job/entity/user_job.entity.ts
@@ -3,6 +3,7 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   JoinTable,
@@ -39,6 +40,10 @@ export class UserEmploymentAndFound extends BaseEntity {
   @Field()
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;
@@ -98,6 +103,10 @@ export class UserInternStatus extends BaseEntity {
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
 
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
+
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;
 
@@ -143,6 +152,10 @@ export class UserHrdNetUtilize extends BaseEntity {
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
 
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
+
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;
 
@@ -175,6 +188,10 @@ export class UserEmploymentStatus extends BaseEntity {
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;

--- a/packages/server/src/user_payment/entity/user_computation_fund.entity.ts
+++ b/packages/server/src/user_payment/entity/user_computation_fund.entity.ts
@@ -3,6 +3,7 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -40,6 +41,10 @@ export class UserComputationFund extends BaseEntity {
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @ManyToOne(() => User, (user) => user.userComputationFund)
   user: User;

--- a/packages/server/src/user_payment/entity/user_education_fund_state.entity.ts
+++ b/packages/server/src/user_payment/entity/user_education_fund_state.entity.ts
@@ -3,6 +3,7 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -52,6 +53,10 @@ export class UserEducationFundState extends BaseEntity {
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @ManyToOne(() => User, (user) => user.userEducationFundState)
   user: User;

--- a/packages/server/src/user_payment/entity/user_payment.entity.ts
+++ b/packages/server/src/user_payment/entity/user_payment.entity.ts
@@ -3,6 +3,7 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   JoinTable,
@@ -47,6 +48,10 @@ export class UserComputationFund extends BaseEntity {
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;
@@ -114,6 +119,10 @@ export class UserEducationFundState extends BaseEntity {
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;

--- a/packages/server/src/user_status/entity/user_status.entity.ts
+++ b/packages/server/src/user_status/entity/user_status.entity.ts
@@ -3,6 +3,7 @@ import {
   BaseEntity,
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   JoinTable,
@@ -55,6 +56,10 @@ export class UserLearningData extends BaseEntity {
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
 
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
+
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;
 
@@ -97,6 +102,10 @@ export class UserProcessProgress extends BaseEntity {
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
 
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
+
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;
 
@@ -133,6 +142,10 @@ export class UserBlackhole extends BaseEntity {
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;
@@ -185,6 +198,10 @@ export class UserLeaveOfAbsence extends BaseEntity {
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
 
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
+
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;
 
@@ -216,6 +233,10 @@ export class UserReasonOfBreak extends BaseEntity {
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: number;
@@ -250,6 +271,10 @@ export class UserLapiscineInformation extends BaseEntity {
 
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
+
+  @Field()
+  @DeleteDateColumn()
+  deleted_date: Date;
 
   @Column({ name: 'fk_user_no', nullable: true })
   fk_user_no: string;


### PR DESCRIPTION
관리자(admin)을 위한 graphql query 및 mutation 구현
각각의 엔터티에 deleted_date 컬럼 추가
사이트이용자(bocal)들의 정보를 저장하는 테이블 추가
filter조건에 take, skip옵션 추가

feat #176

### 작업 동기 (Motivation)
    관리자(루나님과 같은 admin)를 위한 graphql query, mutation을 추가하였습니다.
    
### 변경 사항 요약 (Key changes)
    graphql api를 통해서 DB의 데이터를 update, delete, recover(delete된 것을 recover)하는 것이 가능하게 되었습니다.
    recover이 가능하도록 deleted_date 컬럼을 추가, softRemove 메서드를 사용하였습니다.
    api 사용 명세는 조만간 노션에 업데이트 하겠습니다.

    사이트 이용자(bocal)들의 데이터를 저장하는 테이블인 bocal table을 추가하였습니다.

    (폴라베어님 요청) 하나의 api 요청시 데이터를 몇개씩 들고올수 있는지 정할수있는 옵션을 넣어두었습니다.(skip, take)
    (이것도 노션에 업데이트 해놓겠습니다.)


### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [X] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

