### PR TITLE
fixed: refactoring and api error

### DIFF
--- a/packages/server/src/api/api.service.ts
+++ b/packages/server/src/api/api.service.ts
@@ -59,13 +59,13 @@ export class ApiService {
 
   async requestApi(token) {
     let api_data = [];
-    let page_num = 1;
+    let page_num = 20;
 
     while (1) {
       const temp = await axios({
         method: 'get', // 요청 방식
 
-        url: `https://api.intra.42.fr/v2/cursus/21/cursus_users?filter[campus_id]=29&page[number]=${page_num}&page[size]=100$sort=user_id`,
+        url: `https://api.intra.42.fr/v2/cursus/21/cursus_users?filter[campus_id]=29&page[number]=${page_num}&page[size]=100$sort=-user_id`,
         //url: 'https://api.intra.42.fr/v2/cursus_users/117025', //cursus_id 41값인 외국인 같음 grade도 null 임
         headers: {
           Authorization: `Bearer ${token}`,
@@ -75,11 +75,11 @@ export class ApiService {
 
       //    console.log(page_num);
       // console.log('why ', temp.data.length);
-      console.log(page_num);
+      //console.log(page_num);
 
       if (temp.data.length === 0) {
         //(temp.data == null || temp.data == undefined) {
-        console.log('i got all data from 42api');
+        //console.log('i got all data from 42api');
         break;
       }
       //console.log(temp.data.user.staff);
@@ -104,7 +104,10 @@ export class ApiService {
     let idx = 0;
 
     for (const row in api_data) {
-      if (api_data[row].user['staff?'] == true) {
+      if (
+        api_data[row].user['staff?'] == false &&
+        api_data[row].user.login.split('-')[0] !== 'm'
+      ) {
         parsed_data[idx] = {};
         parsed_data[idx]['intra_no'] = api_data[row].user.id;
         parsed_data[idx]['intra_id'] = api_data[row].user.login;
@@ -123,7 +126,7 @@ export class ApiService {
           api_data[row].blackholed_at,
         );
         idx++;
-        console.log(parsed_data);
+        //console.log(parsed_data);
       }
     }
     return parsed_data;
@@ -181,7 +184,7 @@ export class ApiService {
         return api42;
       }
     }
-    console.log('cant find');
+    //console.log('cant find');
     return -1;
   }
 
@@ -189,7 +192,7 @@ export class ApiService {
     const api = new UserLearningData();
     let api_tuple;
     for (const api42 of api42s) {
-      console.log(api42);
+      //console.log(api42);
       //api.intra_no = api42.id;
       api.circle = api42.circle;
       api.level = api42.level;

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -8,11 +8,11 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 scalar DateTime
 
 input Filter {
-  column: String!
+  column: String
   entityName: String!
-  givenValue: String!
-  latest: Boolean!
-  operator: String!
+  givenValue: String
+  latest: Boolean
+  operator: String
 }
 
 type JoinedTable {
@@ -51,6 +51,7 @@ type Mutation {
 type Query {
   getAllSpread: String!
   getNumOfPeopleByFilter(filters: [Filter!]!, skip: Int, take: Int): Int!
+  getOldData: String!
   getPeopleByFilter(filters: [Filter!]!, skip: Int, take: Int): [JoinedTable!]!
   getPeopleByFilterForAdmin(filters: [Filter!]!, skip: Int, take: Int): [JoinedTable!]!
   getUserAccessCardInformation: [UserAccessCardInformation!]!
@@ -71,6 +72,7 @@ type Query {
 
 type UserAccessCardInformation {
   created_date: DateTime!
+  deleted_date: DateTime!
   lapiscine_logical_number: Int!
   lapiscine_physical_number: Int!
   logical_number_for_main_course: Int!
@@ -82,6 +84,7 @@ type UserAccessCardInformation {
 type UserBlackhole {
   blackhole_time: DateTime!
   created_date: DateTime!
+  deleted_date: DateTime!
   pk: Float!
   reason_of_blackhole: String
   remaining_period: Float
@@ -89,20 +92,22 @@ type UserBlackhole {
 
 type UserComputationFund {
   created_date: DateTime!
-  majoreceived_fundr_field: String!
+  deleted_date: DateTime!
+  is_received_fund: String!
   no_duplicate_collection: String!
   payment_date: DateTime
   pk: Int!
   reason_of_no_duplicate: String
-  recevied_grant_amount: Int!
+  recevied_amount: Int!
 }
 
 type UserEducationFundState {
   created_date: DateTime!
-  fund_period: DateTime
+  deleted_date: DateTime!
+  fund_period: DateTime!
   payment_delay_period: Int
-  payment_give_break_date: DateTime
-  payment_give_start_date: DateTime
+  payment_end_date: DateTime!
+  payment_give_start_date: DateTime!
   pk: Int!
   remaining_period_of_fund: Int
   total_calculated_month: Int!
@@ -111,23 +116,29 @@ type UserEducationFundState {
 }
 
 type UserEmploymentAndFound {
+  consent_to_provide_information: String!
   created_date: DateTime!
+  deleted_date: DateTime!
   employment: String!
   employment_date: DateTime
   enterprise: String
-  pk: Int!
+  pk: Float!
 }
 
 type UserEmploymentStatus {
   created_date: DateTime!
+  deleted_date: DateTime!
   emplyment_date: DateTime
   enterprise: String
+  enterprise_size: String
   pk: Float!
 }
 
 type UserHrdNetUtilize {
   consent_to_provide_information: String!
   created_date: DateTime!
+  deleted_date: DateTime!
+  employment: String!
   employment_insurance_date: DateTime
   enterprise: String
   enterprise_size: String
@@ -136,17 +147,19 @@ type UserHrdNetUtilize {
 
 type UserInternStatus {
   created_date: DateTime!
+  deleted_date: DateTime!
   end_intern_date: Float
   enterprise: DateTime
-  intern_blackhole: Float
-  intern_blackhole_date: DateTime
+  given_blackhole_day: Float
   intern_note: Float
   intern_part_of_job: Float
+  is_given_blackhole: String!
   pk: Float!
   start_intern_date: Float
 }
 
 type UserLapiscineInformation {
+  deleted_date: DateTime!
   lapiscine_degree: String!
   lapiscine_grade: String
   number_of_rapicin_participation: String
@@ -156,9 +169,12 @@ type UserLapiscineInformation {
 
 type UserLearningData {
   circle: Float
-  coalition_score: Float!
+  circle_date: DateTime
+  coalition_score: Float
   created_date: DateTime!
-  level: Float!
+  deleted_date: DateTime!
+  level: Float
+  level_date: DateTime
   out_circle: String
   out_circle_date: DateTime
   pk: Float!
@@ -167,6 +183,7 @@ type UserLearningData {
 type UserLeaveOfAbsence {
   absence_reason: String
   created_date: DateTime!
+  deleted_date: DateTime!
   end_absence_date: DateTime
   pk: Float!
   return_from_absence_date: DateTime
@@ -175,6 +192,7 @@ type UserLeaveOfAbsence {
 
 type UserOtherInformation {
   created_date: DateTime!
+  deleted_date: DateTime!
   experience_of_software_developing: String!
   highest_level_of_education: String!
   major: String!
@@ -198,6 +216,7 @@ type UserPersonalInformation {
 type UserProcessProgress {
   basic_expiration_date: DateTime!
   created_date: DateTime!
+  deleted_date: DateTime!
   final_expiration_date: DateTime!
   pk: Float!
   request_extension: String
@@ -206,6 +225,7 @@ type UserProcessProgress {
 type UserReasonOfBreak {
   created_date: DateTime!
   date_of_break: DateTime!
+  deleted_date: DateTime!
   pk: Float!
   reason_of_break: String
 }

--- a/packages/server/src/updater/name_types/updater.name.ts
+++ b/packages/server/src/updater/name_types/updater.name.ts
@@ -18,7 +18,7 @@ import {
   SUB_T_ID8,
 } from 'src/config/key';
 
-export enum TABLENUM {
+export const enum TABLENUM {
   USER = 0,
   USERPERSONAL = 1,
   USERPROCESSPROGRESS = 2,

--- a/packages/server/src/updater/name_types/updater.name.ts
+++ b/packages/server/src/updater/name_types/updater.name.ts
@@ -1,8 +1,46 @@
 //테이블의 컬럼을 나열해 놓았습니다.
 //컬럼 추가시 여기에 추가해야함
 
+import {
+  SPREAD_END_POINT,
+  SUB_C_ID1,
+  SUB_C_ID2,
+  SUB_C_ID3,
+  SUB_C_ID4,
+  SUB_C_ID5,
+  SUB_T_ID1,
+  SUB_T_ID2,
+  SUB_T_ID3,
+  SUB_T_ID4,
+  SUB_T_ID5,
+  SUB_T_ID6,
+  SUB_T_ID7,
+  SUB_T_ID8,
+} from 'src/config/key';
+
+export enum TABLENUM {
+  USER = 0,
+  USERPERSONAL = 1,
+  USERPROCESSPROGRESS = 2,
+  USERLEAVEOFABSENCE = 3,
+  USERBLACKHOLE = 4,
+  USERREASONOFBREAK = 5,
+  USEROTHERINFORMATION = 6,
+  USERLAPISCINEINFORMATION = 7,
+  USERINTERNSTATUS = 8,
+  USEREMPLOYMENTANDFOUND = 9,
+  USEREMPLOYMENTSTATUS = 10,
+  USERHRDNETUTILIZE = 11,
+  USEREDUCATIONFUNDSTATE = 12,
+  USERCOMPUTATIONFUND = 13,
+  USERACCESSCARD = 14,
+  USERLEARNINGDATA = 15,
+}
+
 export const mapObj = [
+  //메인1
   [
+    //user
     { spName: 'Intra No.', dbName: 'intra_no' },
     { spName: 'Intra ID', dbName: 'intra_id' },
     { spName: '성명', dbName: 'name' },
@@ -13,6 +51,7 @@ export const mapObj = [
     { spName: '특이사항', dbName: 'uniqueness' }, //테이블에 없음
   ],
   [
+    //userpersonal
     { spName: '개인정보관리 지역', dbName: 'region' },
     { spName: '성별', dbName: 'gender' },
     { spName: '생년월일', dbName: 'birthday' },
@@ -22,11 +61,13 @@ export const mapObj = [
     //이메일, 전화번호는 api
   ],
   [
+    //userProcessProgress
     { spName: '과정진행여부 기본종료일자', dbName: 'basic_expiration_date' },
     { spName: '과정연장신청', dbName: 'request_extension' },
     { spName: '최종 종료일', dbName: 'final_expiration_date' },
   ],
   [
+    //userLeaveOfAbsence (+ 휴학기간)
     { spName: '휴학 총 휴학개월 수', dbName: 'intra_no' }, //테이블에 없음
     { spName: '시작일자', dbName: 'start_absence_date' },
     { spName: '종료일자', dbName: 'end_absence_date' },
@@ -34,49 +75,86 @@ export const mapObj = [
     { spName: '사유', dbName: 'absence_reason' },
   ],
   [
+    //userBlackhole
     { spName: '잔여기간', dbName: 'remaining_period' },
     { spName: '블랙홀일자', dbName: 'blackhole_date' },
     { spName: '블랙홀 사유', dbName: 'reason_of_blackhole' },
     //잔여기간, 블랙홀일자는 api -> 추가함
   ],
   [
+    //userReasonOfBreak
     { spName: '과정중단 과정중단일자', dbName: 'date_of_break' },
     { spName: '중단사유', dbName: 'reason_of_break' },
   ],
   [
+    // userOtherRepository
     { spName: '기타정보 최종학력', dbName: 'highest_level_of_education' },
     { spName: '소프트웨어 관련전공여부', dbName: 'major' },
     { spName: '전공명(복수전공기재)', dbName: 'major_name' },
   ],
   [
+    //userLapiscineInformation
     { spName: '라피신정보 관리 라피신 기수', dbName: 'lapiscine_grade' },
     { spName: '라피신 차수', dbName: 'lapiscine_degree' },
     { spName: '라피신 참여이력', dbName: 'participate_lapicin' },
   ],
   [
-    { spName: '취창업지원관리 취업', dbName: 'employment' },
+    //userInternStatus //하위시트 참고 새롭게 추가
+    { spName: '인턴시작일자', dbName: 'start_intern_date' },
+    { spName: '인턴종료일자', dbName: 'end_intern_date' },
+    { spName: '인턴참여회사', dbName: 'enterprise' },
+    { spName: '인턴직무', dbName: 'intern_part_of_job' },
+    { spName: '인턴관련블랙홀지급여부', dbName: 'is_given_blackhole' },
+    { spName: '인턴관련블랙홀지급일수', dbName: 'given_blackhole_day' },
+    { spName: '인턴관련비고', dbName: 'intern_note' },
+  ],
+  [
+    //userEmploymentAndFound
+    { spName: '취창업지원관리 취업', dbName: 'employment' }, //하위시트에서 고민중 구글시트에 없음.
     { spName: '취업일자', dbName: 'employment_date' },
+    { spName: '사업장명', dbName: 'enterprise' },
+    {
+      spName: 'HRD사용 여부',
+      dbName: 'consent_to_provide_information', //하위시트 참고 새롭게 추가
+    },
+  ],
+  [
+    //userEmploymentStatus //하위시트 참고 새롭게 추가
+    { spName: '고용보험가입일', dbName: 'emplyment_date' },
+    { spName: '기업규모', dbName: 'enterprise_size' },
     { spName: '사업장명', dbName: 'enterprise' },
   ],
   [
+    //userHrdNetUtilize
     {
       spName: 'HRD-Net 활용 정보제공동의',
-      dbName: 'consent_to_provide_information',
-    },
+      dbName: 'consent_to_provide_information', //하위시트 참고 삭제고려
+    }, //제거해야할 수도
+    { spName: '취업여부', dbName: 'employment' }, //하위시트 참고 새롭게 추가
+    { spName: '고용보험가입일', dbName: 'employment_insurance_date' }, //하위시트 참고 새롭게 추가
+    { spName: '기업규모', dbName: 'enterprise_size' }, //하위시트 참고 새롭게 추가
+    { spName: '사업장명', dbName: 'enterprise' }, //하위시트 참고 새롭게 추가
   ],
   [
+    //userEducationFundState
     {
       spName: '교육지원금 관리 총 산정월(미지급월포함)',
       dbName: 'total_payment_of_number',
-    },
+    }, //구글 하위 시트에 과정시작일이 있으나 중복이어서 추가하지 않음.
     { spName: '총 지급액', dbName: 'total_payment_of_money' },
-    { spName: '잔여지원기간', dbName: 'remaining_period_of_fund' },
+    { spName: '지원금지급시작일자', dbName: 'payment_give_start_date' }, //하위시트 참고 새롭게 추가
+    { spName: '지원금유예기간', dbName: 'payment_delay_period' }, //하위시트 참고 새롭게 추가
+    { spName: '지원자지급종료일자', dbName: 'payment_end_date' }, //하위시트 참고 새롭게 추가
+    { spName: '잔여지원기간', dbName: 'remaining_period_of_fund' }, //하위시트 참고 새롭게 추가
   ],
   [
-    { spName: '지원금산정 지원금수령여부', dbName: 'received_fund' },
-    { spName: '지원금수령금액', dbName: 'recevied_grant_amount' },
+    //userComputationFund
+    { spName: '지원금산정 지원금수령여부', dbName: 'is_received_fund' }, //지급일 추가해야함
+    { spName: '지원금수령금액', dbName: 'recevied_amount' },
+    { spName: '지급일', dbName: 'payment_date' }, //하위시트 참고 새롭게 추가
   ],
   [
+    //userAccessCardRepository
     { spName: '출입카드정보 사진이미지파일', dbName: 'profile_picture_url' },
     {
       spName: '라피신출입카드물리번호',
@@ -95,27 +173,176 @@ export const mapObj = [
       dbName: 'name_of_entry_card_for_main_course',
     },
   ],
+  [
+    {
+      spName: '서클',
+      dbName: 'circle',
+    },
+    {
+      spName: '서클일자',
+      dbName: 'circle_date',
+    },
+    {
+      spName: '레벨',
+      dbName: 'level',
+    },
+    {
+      spName: '레벨일자',
+      dbName: 'level_date',
+    },
+  ],
 ];
 
 //테이블의 경계
 
 export const endOfTable = [
+  //메인2
   '학사정보 no.',
   '개인정보관리 지역',
   '과정진행여부 기본종료일자',
   '휴학 총 휴학개월 수',
   '블랙홀 사유',
   '과정중단 과정중단일자',
-  //'학습데이터',
   '기타정보 최종학력',
   '라피신정보 관리 라피신 기수',
-  //'인턴현황',
+  '인턴현황',
   '취창업지원관리 취업',
-  //'기타취업현황',
+  '기타취업현황',
   'HRD-Net 활용 정보제공동의',
   '교육지원금 관리 총 산정월(미지급월포함)',
   '지원금산정 지원금수령여부',
   '출입카드정보 사진이미지파일',
+  '학습데이터',
+];
+
+export const pastDataOnSheet = [
+  //하위1
+  {
+    //유저
+    endPoint: null,
+    Id: null,
+    columns: mapObj[TABLENUM.USER],
+    table: TABLENUM.USER,
+  },
+  {
+    //개인정보
+    endPoint: null,
+    Id: null,
+    columns: mapObj[TABLENUM.USERPERSONAL],
+    table: TABLENUM.USERPERSONAL,
+  },
+  {
+    //과정진행여부
+    endPoint: null,
+    Id: null,
+    columns: mapObj[TABLENUM.USERPROCESSPROGRESS],
+    table: TABLENUM.USERPROCESSPROGRESS,
+  },
+  {
+    // 휴학
+    endPoint: SPREAD_END_POINT,
+    Id: SUB_T_ID1,
+    columns: mapObj[TABLENUM.USERLEAVEOFABSENCE],
+    table: TABLENUM.USERLEAVEOFABSENCE,
+  },
+  {
+    // 블랙홀
+    endPoint: SPREAD_END_POINT,
+    Id: SUB_T_ID2,
+    columns: mapObj[TABLENUM.USERBLACKHOLE],
+    table: TABLENUM.USERBLACKHOLE,
+  },
+  {
+    // 과정중단
+    endPoint: SPREAD_END_POINT,
+    Id: SUB_T_ID3,
+    columns: mapObj[TABLENUM.USERREASONOFBREAK],
+    table: TABLENUM.USERREASONOFBREAK,
+  },
+  {
+    //기타정보
+    endPoint: null,
+    Id: null,
+    columns: mapObj[TABLENUM.USEROTHERINFORMATION],
+    table: TABLENUM.USEROTHERINFORMATION,
+  },
+  {
+    //라피신정보
+    endPoint: null,
+    Id: null,
+    columns: mapObj[TABLENUM.USERLAPISCINEINFORMATION],
+    table: TABLENUM.USERLAPISCINEINFORMATION,
+  },
+  {
+    // 인턴정보 //취업창업지원관리 시트와 겹침
+    endPoint: SPREAD_END_POINT,
+    Id: SUB_T_ID6,
+    columns: mapObj[TABLENUM.USERINTERNSTATUS],
+    table: TABLENUM.USERINTERNSTATUS,
+  },
+  {
+    // 취창업지원관리
+    endPoint: SPREAD_END_POINT,
+    Id: SUB_T_ID4,
+    columns: mapObj[TABLENUM.USEREMPLOYMENTANDFOUND],
+    table: TABLENUM.USEREMPLOYMENTANDFOUND,
+  },
+  {
+    //기타취업
+    endPoint: SPREAD_END_POINT,
+    Id: SUB_T_ID5,
+    columns: mapObj[TABLENUM.USEREMPLOYMENTSTATUS],
+    table: TABLENUM.USEREMPLOYMENTSTATUS,
+  },
+  {
+    // HRD고용보험
+    endPoint: SPREAD_END_POINT,
+    Id: SUB_T_ID7,
+    columns: mapObj[TABLENUM.USERHRDNETUTILIZE],
+    table: TABLENUM.USERHRDNETUTILIZE,
+  },
+  {
+    // 교육지원금관리
+    endPoint: SPREAD_END_POINT,
+    Id: SUB_T_ID8,
+    columns: mapObj[TABLENUM.USEREDUCATIONFUNDSTATE],
+    table: TABLENUM.USEREDUCATIONFUNDSTATE,
+  },
+  {
+    // 지원금산정
+    endPoint: null,
+    Id: null,
+    columns: mapObj[TABLENUM.USERCOMPUTATIONFUND],
+    table: TABLENUM.USERCOMPUTATIONFUND,
+  },
+  {
+    // 출입카드정보
+    endPoint: null,
+    Id: null,
+    columns: mapObj[TABLENUM.USERACCESSCARD],
+    table: TABLENUM.USERACCESSCARD,
+  },
+  {
+    // 학습데이터(api)
+    endPoint: null,
+    Id: null,
+    columns: mapObj[TABLENUM.USERLEARNINGDATA],
+    table: TABLENUM.USERLEARNINGDATA,
+  },
+];
+
+export const pastDataOnColumn = [
+  //하위컬럼1
+  {
+    endPoint: SPREAD_END_POINT,
+    Id: [SUB_C_ID1, SUB_C_ID2, SUB_C_ID3],
+    table: TABLENUM.USERCOMPUTATIONFUND,
+  },
+  {
+    endPoint: SPREAD_END_POINT,
+    Id: [SUB_C_ID4, SUB_C_ID5],
+    table: TABLENUM.USERLEARNINGDATA,
+  },
 ];
 
 export const apiOfTable = ['학습데이터'];

--- a/packages/server/src/updater/updater.controller.ts
+++ b/packages/server/src/updater/updater.controller.ts
@@ -6,7 +6,7 @@ export class UpdaterController {
   constructor(private updaterService: UpdaterService) {}
 
   @Get()
-  getAllSpread(): Promise<string> {
+  getAllSpread() {
     return this.updaterService.getAllSpread();
   }
 }

--- a/packages/server/src/updater/updater.module.ts
+++ b/packages/server/src/updater/updater.module.ts
@@ -13,10 +13,6 @@ import {
   UserInternStatus,
 } from 'src/user_job/entity/user_job.entity';
 import {
-  UserComputationFund,
-  UserEducationFundState,
-} from 'src/user_payment/entity/user_payment.entity';
-import {
   UserBlackhole,
   UserLapiscineInformation,
   UserLearningData,
@@ -26,6 +22,8 @@ import {
 } from 'src/user_status/entity/user_status.entity';
 import { UpdaterController } from './updater.controller';
 import { ApiService } from 'src/api/api.service';
+import { UserComputationFund } from 'src/user_payment/entity/user_computation_fund.entity';
+import { UserEducationFundState } from 'src/user_payment/entity/user_education_fund_state.entity';
 
 @Module({
   imports: [

--- a/packages/server/src/updater/updater.resolver.ts
+++ b/packages/server/src/updater/updater.resolver.ts
@@ -12,4 +12,9 @@ export class UpdaterResolver {
   getAllSpread() {
     return this.updaterService.getAllSpread();
   }
+
+  @Query(() => String)
+  getOldData() {
+    return this.updaterService.getOldData();
+  }
 }

--- a/packages/server/src/updater/updater.service.ts
+++ b/packages/server/src/updater/updater.service.ts
@@ -1,5 +1,9 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  CacheKey,
+} from '@nestjs/common';
 import axios from 'axios';
 import { ApiService } from 'src/api/api.service';
 import { CreateApiDto } from 'src/api/dto/create-api.dto';
@@ -10,6 +14,7 @@ import {
   SHEET_ID2,
   SPREAD_END_POINT,
 } from 'src/config/key';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { UserAccessCardInformation } from 'src/user_information/entity/user_access_card_information.entity';
 import { User } from 'src/user_information/entity/user_information.entity';
 import { UserOtherInformation } from 'src/user_information/entity/user_other_information.entity';
@@ -20,10 +25,8 @@ import {
   UserHrdNetUtilize,
   UserInternStatus,
 } from 'src/user_job/entity/user_job.entity';
-import {
-  UserComputationFund,
-  UserEducationFundState,
-} from 'src/user_payment/entity/user_payment.entity';
+import { UserComputationFund } from 'src/user_payment/entity/user_computation_fund.entity';
+import { UserEducationFundState } from 'src/user_payment/entity/user_education_fund_state.entity';
 import {
   UserBlackhole,
   UserLapiscineInformation,
@@ -32,8 +35,16 @@ import {
   UserProcessProgress,
   UserReasonOfBreak,
 } from 'src/user_status/entity/user_status.entity';
-import { Repository } from 'typeorm';
-import { apiOfTable, endOfTable, mapObj } from './name_types/updater.name';
+import { Column, DataSource, Repository } from 'typeorm';
+import { SingleEntryPlugin } from 'webpack';
+import {
+  apiOfTable,
+  endOfTable,
+  mapObj,
+  pastDataOnColumn,
+  pastDataOnSheet,
+  TABLENUM,
+} from './name_types/updater.name';
 
 @Injectable() //총 16개의 테이블
 export class UpdaterService {
@@ -71,17 +82,17 @@ export class UpdaterService {
     @InjectRepository(UserLapiscineInformation)
     private userLapiscineInformation: Repository<UserLapiscineInformation>,
     private apiService: ApiService,
+    @InjectDataSource()
+    private dataSource: DataSource,
   ) {}
 
   async getAllSpread(): Promise<string> {
     let jsonData;
-    let spreadData;
     let tableNum = 0;
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const axios = require('axios');
     let index = 0;
 
     const repoArray = [
+      //메인3
       this.userRepository,
       this.userPersonalRepository,
       this.userProcessProgress,
@@ -91,7 +102,9 @@ export class UpdaterService {
 
       this.userOtherRepository,
       this.userLapiscineInformation,
+      this.userInternStatus,
       this.userEmploymentAndFound,
+      this.userEmploymentStatus,
       this.userHrdNetUtilize,
       this.userEducationFundState,
       this.userComputationFund,
@@ -100,26 +113,9 @@ export class UpdaterService {
 
     const apiOfRepo = [this.userLearningData];
 
-    await axios({
-      method: 'get',
-      url: `http://spreadsheets.google.com/tq?key=${SPREAD_END_POINT}&pub=1&gid=${SHEET_ID2}`,
-    })
-      .then(function (response) {
-        const rawdata = response.data;
-
-        const temp = '/*O_o*/\ngoogle.visualization.Query.setResponse(';
-        const temp2 = '';
-        const temp3 = ');';
-
-        const rawdata2 = rawdata.replace(temp, temp2);
-        spreadData = rawdata2.replace(temp3, temp2);
-      })
-      .catch(function (err) {
-        console.log(err); // 에러 처리 내용
-      });
     // eslint-disable-next-line prefer-const
-    jsonData = spreadData;
-    //console.log(jsonData, 'jsonData');
+    jsonData = await this.sendRequestToSpread(SPREAD_END_POINT, SHEET_ID2);
+
     const obj = JSON.parse(jsonData);
     const cols = obj.table.cols;
     const rows = obj.table.rows;
@@ -133,15 +129,22 @@ export class UpdaterService {
       if (cols[col]['label'] === endOfTable[tableNum])
         //tablle num 을 추가시키면서 label과 같은지 찾기, endoftable과 clos의 수가 같아서 가능
         index = await this.parseSpread(
+          //인턴현황과 기타취업현황 추가됨.
           cols,
           rows,
           index,
           repoArray[tableNum],
           mapObj[tableNum],
-          endOfTable[++tableNum],
+          endOfTable,
+          ++tableNum,
           api42s,
         );
-      //console.log("table nun" , tableNum);
+      else if (
+        //endOfTable에 하위시트를 대비하여 메인에 없는 시트들이 생김
+        cols.find((Column) => Column.label === endOfTable[tableNum]) ===
+        undefined
+      )
+        tableNum++;
     }
     for (const api_table in apiOfTable) {
       if (apiOfTable[api_table] == '학습데이터') {
@@ -152,12 +155,17 @@ export class UpdaterService {
     return await 'finish';
   }
 
+  onlyNumbers(str) {
+    return /^[0-9]+$/.test(str);
+  }
+
   change_date(str: string): string {
+    //console.log(str);
     const convStr = str.replace(/. /g, '-');
     const tmp = new Date(convStr);
     const insertHyphen = (str, sub) =>
       `${str.slice(0, 4)}${sub}${str.slice(4, 6)}${sub}${str.slice(6)}`;
-    if (str === convStr) return insertHyphen(str, '-');
+    if (str === convStr && this.onlyNumbers(str)) return insertHyphen(str, '-');
     //생년월일에 - 추가해야함
     const year = tmp.getFullYear();
     const tmpMonth = tmp.getMonth() + 1;
@@ -167,29 +175,45 @@ export class UpdaterService {
     return year + '-' + month + '-' + day;
   }
 
+  checkEnd(endpoint, endOfTable, label) {
+    for (const idx in endOfTable) {
+      if (Number(idx) < endpoint) continue;
+      if (endOfTable[Number(idx)] === label) return 1;
+    }
+    return 0;
+  }
+
   async parseSpread(
     cols,
     rows,
     colIdx: number,
     Repo,
     mapObj,
-    endOfTable: string,
-    api42s,
+    endOfTable,
+    tableNum?, // 하위시트는 넘버가 필요없음.
+    api42s?,
   ): Promise<number> {
     let tupleLine;
     let idx; //특정 테이블에 있는 컬럼인지 검사하는 색인
     let jdx = colIdx; //컬럼의 위치 튜플의 도메인 위치 맞춰주기 위한 색인
-    //console.log(rows, 'rowss');
+    const check = endOfTable + 1;
+
     for (const row of rows) {
       const tuple = {};
       jdx = colIdx; //특정 테이블의 시작에 해당하는 컬럼의 색인으로 초기화
       while (1) {
-        if (cols[jdx] === undefined || cols[jdx]['label'] === endOfTable) {
-          console.log('breaked-----');
+        //하나의 로우 완성
+        idx = 0;
+        if (
+          cols[jdx] === undefined ||
+          this.checkEnd(tableNum, endOfTable, cols[jdx]['label']) //테이블이 추가됨에 따라 확장성을 고려해서 추가함
+        ) {
           break;
-        } else if (row['c'][jdx] === null) {
-          tuple[`${cols[jdx]['label']}`] = null; //셀값이 null인 경우 별도의 처리
-          console.log(tuple[`${cols[jdx]['label']}`], 'null?');
+        } else if (
+          row['c'][jdx] === null &&
+          (idx = this.compareColumn(cols[jdx]['label'], mapObj)) !== -1
+        ) {
+          //tuple[`${mapObj[idx].dbName}`] = null; //셀값이 null인 경우 별도의 처리 //위의 경우 다음 걸로 패스 어차피 없으면 null을 넣음.
         } else if (
           (idx = this.compareColumn(cols[jdx]['label'], mapObj)) !== -1
         ) {
@@ -232,5 +256,238 @@ export class UpdaterService {
       if (label === objs[obj].spName) return Number(obj);
     }
     return -1;
+  }
+
+  async sendRequestToSpread(endPoint: string, id: string) {
+    let spreadData;
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const axios = require('axios');
+
+    await axios({
+      method: 'get',
+      url: `http://spreadsheets.google.com/tq?key=${endPoint}&pub=1&gid=${id}`,
+    })
+      .then(function (response) {
+        const rawdata = response.data;
+
+        const temp = '/*O_o*/\ngoogle.visualization.Query.setResponse(';
+        const temp2 = '';
+        const temp3 = ');';
+
+        const rawdata2 = rawdata.replace(temp, temp2);
+        spreadData = rawdata2.replace(temp3, temp2);
+      })
+      .catch(function (err) {
+        console.log(err); // 에러 처리 내용
+      });
+
+    return await spreadData;
+  }
+
+  async getOldSheetLogColumns(colObj) {
+    const colDatas = [];
+
+    let date;
+
+    for (const idx in colObj.Id) {
+      //시트의 총 장수 만큼 반복
+      const jsonData = await this.sendRequestToSpread(
+        colObj.endPoint,
+        colObj.Id[idx],
+      );
+      const obj = JSON.parse(jsonData);
+      colDatas.push(obj);
+    }
+    if (colObj.table === TABLENUM.USERCOMPUTATIONFUND) {
+      const datas = [];
+      for (const colData of colDatas) {
+        const cols = colData.table.cols;
+        const rows = colData.table.rows;
+        this.makeAColumnInTable(cols, rows, datas, date);
+      }
+      await this.dataSource
+        .createQueryBuilder()
+        .insert()
+        .into(UserComputationFund)
+        .values(datas)
+        .execute();
+    }
+    if (colObj.table === TABLENUM.USERLEARNINGDATA) {
+      const datas = [];
+      for (const colData in colDatas) {
+        const cols = colDatas[colData].table.cols;
+        const rows = colDatas[colData].table.rows;
+
+        if (colData === '0')
+          this.makeColumnsInTable(cols, rows, datas, date, 1, 0);
+        else if (colData === '1')
+          this.makeColumnsInTable(cols, rows, datas, date, 3, 2);
+        await this.dataSource
+          .createQueryBuilder()
+          .insert()
+          .into(UserLearningData)
+          .values(datas)
+          .execute();
+      }
+    }
+    return colDatas;
+  }
+
+  makeAColumnInTable(cols, rows, datas, date) {
+    for (const col in cols) {
+      if (cols[col]['pattern'] === 'yyyy. mm. dd') {
+        for (const row in rows) {
+          const payment_data = {};
+          if (row === '0') {
+            date = rows[row]['c'][col]['f'];
+            continue;
+          }
+          if (rows[row]['c'][col] === null) continue;
+          payment_data[mapObj[TABLENUM.USERCOMPUTATIONFUND][2].dbName] =
+            this.change_date(date);
+          payment_data[mapObj[TABLENUM.USERCOMPUTATIONFUND][1].dbName] = Number(
+            rows[row]['c'][col]['f'].replace(/\,/g, ''),
+          );
+          if (rows[row]['c'][col]['f'] != '0')
+            payment_data[mapObj[TABLENUM.USERCOMPUTATIONFUND][0].dbName] = 'Y';
+          payment_data['fk_user_no'] = rows[row]['c'][1]['f'];
+          datas.push(payment_data);
+        }
+      }
+    }
+  }
+
+  makeColumnsInTable(cols, rows, datas, date, idx1, idx2) {
+    //한테이블에 두개이상 컬럼을 추가하는 경우
+    for (const col in cols) {
+      if (cols[col]['pattern'] === 'yyyy. mm. dd') {
+        for (const row in rows) {
+          const inputData = {};
+          if (row === '0') {
+            date = rows[row]['c'][col]['f'];
+            continue;
+          }
+          if (rows[row]['c'][col] === null) continue;
+          inputData[mapObj[TABLENUM.USERLEARNINGDATA][idx1].dbName] =
+            this.change_date(date);
+          inputData[mapObj[TABLENUM.USERLEARNINGDATA][idx2].dbName] = Number(
+            rows[row]['c'][col]['f'],
+          );
+          inputData['fk_user_no'] = rows[row]['c'][1]['f'];
+
+          datas.push(inputData);
+        }
+      }
+    }
+  }
+
+  async parseOldSpread(cols, rows, pastSheetData) {
+    let tupleLine;
+
+    for (const row of rows) {
+      //학생의 수 만큼 반복
+      const tuple = {};
+      const columns = pastSheetData.columns; // 해당 시트 테이블의 컬럼들
+      let idx;
+      for (const col in cols) {
+        //컬럼 수 만큼 반복
+        if (
+          row['c'][col] === null &&
+          (idx = this.compareColumn(cols[col]['label'], columns)) !== -1
+        ) {
+          continue;
+        } else if (
+          (idx = this.compareColumn(cols[col]['label'], columns)) !== -1
+        ) {
+          if (cols[col]['type'] === 'date')
+            //타입이 date인 경우 변환처리해줘야 db에 적용됨
+            tuple[`${columns[idx].dbName}`] = this.change_date(
+              row['c'][col]['f'],
+            );
+          else if (row['c'][col]['v'] !== null) {
+            //여기서 한사람이 지금껏 받은 지원금의 모든 컬럼을 넣을 것
+            tuple[`${columns[idx].dbName}`] = row['c'][col]['v'];
+          }
+        }
+      }
+      tupleLine = await pastSheetData['repo'].create(tuple);
+      tupleLine['fk_user_no'] = row['c'][1]['f']; //취업정보, 고용보험 시트의 경우 변경을 해줘야함.
+      await pastSheetData['repo'].save(tupleLine);
+    }
+  }
+
+  async getOldSheetTable(pastSheetData) {
+    let colObj;
+    // let colDatas;
+    const jsonData = await this.sendRequestToSpread(
+      pastSheetData.endPoint,
+      pastSheetData.Id,
+    );
+    const obj = JSON.parse(jsonData);
+    const cols = obj.table.cols;
+    const rows = obj.table.rows;
+
+    //지급일 시트 정보 받아서 저장해두기 테이블 관계수정 //확장성을 고려하려 했으나, 지원금 시트(LogColumn)의 특징이 강력하여 함수를 하나 더 만들기로 결정
+
+    await this.parseOldSpread(cols, rows, pastSheetData);
+  }
+
+  async getOldData() {
+    /* 지원금 관련 월별 지금액 시트 */
+    //this.sendRequestToSpread();
+    /* 테이블 별 과거 데이터 */
+    let colObj;
+    let pastColumn;
+
+    const pastDataRepoArray = [
+      //하위2
+      this.userRepository,
+      this.userPersonalRepository,
+      this.userProcessProgress,
+      this.userLeaveOfAbsence,
+      this.userBlackhole,
+      this.userReasonOfBreak,
+      this.userOtherRepository,
+      this.userLapiscineInformation,
+      this.userInternStatus,
+      this.userEmploymentAndFound,
+      this.userEmploymentStatus,
+      this.userHrdNetUtilize,
+      this.userEducationFundState,
+      this.userComputationFund,
+      this.userAccessCardRepository,
+    ];
+    let jsonData;
+    let index = 0;
+
+    // eslint-disable-next-line prefer-const
+    jsonData = await this.sendRequestToSpread(SPREAD_END_POINT, SHEET_ID2);
+
+    const obj = JSON.parse(jsonData);
+    const cols = obj.table.cols;
+    const rows = obj.table.rows;
+
+    index = await this.parseSpread(
+      cols,
+      rows,
+      index,
+      this.userRepository,
+      mapObj[0],
+      endOfTable[1],
+    );
+    for (const sheetIdx in pastDataOnSheet) {
+      //시트의 총 장수 만큼 반복
+      if (pastDataOnSheet[sheetIdx].endPoint) {
+        pastDataOnSheet[sheetIdx]['repo'] = pastDataRepoArray[sheetIdx];
+        await this.getOldSheetTable(pastDataOnSheet[sheetIdx]);
+      } else if (
+        (pastColumn = pastDataOnColumn.find(
+          (Column) => Column.table === pastDataOnSheet[sheetIdx].table,
+        )) != undefined
+      ) {
+        await this.getOldSheetLogColumns(pastColumn);
+      }
+    }
+    return await 'finish';
   }
 }

--- a/packages/server/src/user_information/entity/user_access_card_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_access_card_information.entity.ts
@@ -50,11 +50,12 @@ export class UserAccessCardInformation extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  // @Column({ name: 'fk_user_no', nullable: true })
-  // fk_user_no: string;
+  @Column({ name: 'fk_user_no', nullable: false })
+  fk_user_no: string;
 
   @OneToOne(() => User, (user) => user.userAccessCardInformation, {
     createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
   })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;

--- a/packages/server/src/user_information/entity/user_other_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_other_information.entity.ts
@@ -52,10 +52,13 @@ export class UserOtherInformation extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userOtherInformation)
+  @ManyToOne(() => User, (user) => user.userOtherInformation, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }

--- a/packages/server/src/user_information/entity/user_personal_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_personal_information.entity.ts
@@ -47,11 +47,13 @@ export class UserPersonalInformation {
   @Field()
   @DeleteDateColumn()
   deleted_date: Date;
-  // @Column({ name: 'fk_user_no', nullable: true })
-  // fk_user_no: string; //외래키값을 선언하지 않으면 null으로 판단됨
+
+  @Column({ name: 'fk_user_no', nullable: false })
+  fk_user_no: string; //외래키값을 선언하지 않으면 null으로 판단됨
 
   @OneToOne(() => User, (user) => user.userPersonalInformation, {
     createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
   })
   @JoinColumn() //user와 이름이 중복되는 에러로 인해 이름변경
   user: User;

--- a/packages/server/src/user_information/entity/user_personal_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_personal_information.entity.ts
@@ -55,6 +55,6 @@ export class UserPersonalInformation {
     createForeignKeyConstraints: false, //외래키 제약조건 해제
     nullable: false,
   })
-  @JoinColumn() //user와 이름이 중복되는 에러로 인해 이름변경
+  @JoinColumn({ name: 'fk_user_no' }) //user와 이름이 중복되는 에러로 인해 이름변경
   user: User;
 }

--- a/packages/server/src/user_job/entity/user_job.entity.ts
+++ b/packages/server/src/user_job/entity/user_job.entity.ts
@@ -16,7 +16,7 @@ import { User } from '../../user_information/entity/user_information.entity';
 @ObjectType()
 @Entity()
 export class UserEmploymentAndFound extends BaseEntity {
-  @Field((type) => Int)
+  @Field()
   @PrimaryGeneratedColumn({ name: 'pk' })
   pk: number;
 
@@ -37,6 +37,14 @@ export class UserEmploymentAndFound extends BaseEntity {
   @Column({ name: 'enterprise', nullable: true })
   enterprise: string;
 
+  @Field({ nullable: false }) //HRD에서 옮겨옴
+  @Column({
+    name: 'consent_to_provide_information',
+    nullable: false,
+    default: 'N',
+  })
+  consent_to_provide_information: string;
+
   @Field()
   @CreateDateColumn({ name: 'created_date' })
   created_date: Date;
@@ -45,10 +53,13 @@ export class UserEmploymentAndFound extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userEmploymentAndFound)
+  @ManyToOne(() => User, (user) => user.userEmploymentAndFound, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }
@@ -82,18 +93,17 @@ export class UserInternStatus extends BaseEntity {
   @Column({ name: 'intern_part_of_job', nullable: true })
   intern_part_of_job: number;
 
-  @Field({ nullable: true })
-  @Column({ name: 'intern_blackhole', nullable: true })
-  intern_blackhole: number;
-
-  @Field({ nullable: true })
+  @Field({ nullable: false }) //인턴관련 블랙홀지급 여부라서 타입수정
   @Column({
-    name: 'intern_blackhole_date',
+    name: 'is_given_blackhole',
     nullable: false,
-    default: '9999-12-31',
-    type: 'date',
+    default: 'N',
   })
-  intern_blackhole_date: Date;
+  is_given_blackhole: string;
+
+  @Field({ nullable: true }) //지급 일수라 타입 수정함
+  @Column({ name: 'given_blackhole_day', nullable: true })
+  given_blackhole_day: number;
 
   @Field({ nullable: true })
   @Column({ name: 'intern_note', nullable: true })
@@ -107,10 +117,13 @@ export class UserInternStatus extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userInternStatus)
+  @ManyToOne(() => User, (user) => user.userInternStatus, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }
@@ -123,13 +136,17 @@ export class UserHrdNetUtilize extends BaseEntity {
   @PrimaryGeneratedColumn({ name: 'pk' })
   pk: number;
 
-  @Field({ nullable: false })
+  @Field({ nullable: false }) //현재 userEmploymentAndFound와 중복됨.
   @Column({
     name: 'consent_to_provide_information',
     nullable: false,
     default: 'N',
   })
   consent_to_provide_information: string;
+
+  @Field({ nullable: false, defaultValue: 'N' }) //UserEmploymentAndFound 에서 옮겨옴
+  @Column({ name: 'employment', nullable: false, default: 'N' })
+  employment: string;
 
   @Field({ nullable: true })
   @Column({
@@ -156,10 +173,13 @@ export class UserHrdNetUtilize extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userHrdNetUtilize)
+  @ManyToOne(() => User, (user) => user.userHrdNetUtilize, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }
@@ -182,6 +202,10 @@ export class UserEmploymentStatus extends BaseEntity {
   emplyment_date: Date;
 
   @Field({ nullable: true })
+  @Column({ name: 'enterprise_size', nullable: true })
+  enterprise_size: string; //구글하위시트에 있음... 추가
+
+  @Field({ nullable: true })
   @Column({ name: 'enterprise', nullable: true })
   enterprise: string;
 
@@ -193,10 +217,13 @@ export class UserEmploymentStatus extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userEmploymentStatus)
+  @ManyToOne(() => User, (user) => user.userEmploymentStatus, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }

--- a/packages/server/src/user_payment/entity/user_computation_fund.entity.ts
+++ b/packages/server/src/user_payment/entity/user_computation_fund.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -27,14 +28,14 @@ export class UserComputationFund extends BaseEntity {
   reason_of_no_duplicate: string;
 
   @Field({ nullable: false })
-  @Column({ name: 'received_fund', nullable: false, default: 'N' })
-  majoreceived_fundr_field: string;
+  @Column({ name: 'is_received_fund', nullable: false, default: 'N' })
+  is_received_fund: string; //이름 오타 수정
 
   @Field((type) => Int, { nullable: false })
-  @Column({ name: 'recevied_grant_amount', nullable: false, default: 0 })
-  recevied_grant_amount: number;
+  @Column({ name: 'recevied_amount', nullable: false, default: 0 }) //이름수정
+  recevied_amount: number;
 
-  @Field({ nullable: true })
+  @Field({ nullable: true }) //지급일 추가예정
   @Column({ name: 'payment_date', nullable: true })
   payment_date: Date;
 
@@ -47,5 +48,13 @@ export class UserComputationFund extends BaseEntity {
   deleted_date: Date;
 
   @ManyToOne(() => User, (user) => user.userComputationFund)
+  @Column({ name: 'fk_user_no', nullable: false })
+  fk_user_no: string;
+
+  @ManyToOne(() => User, (user) => user.userComputationFund, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
+  @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }

--- a/packages/server/src/user_payment/entity/user_education_fund_state.entity.ts
+++ b/packages/server/src/user_payment/entity/user_education_fund_state.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -14,7 +15,7 @@ import { User } from '../../user_information/entity/user_information.entity';
 @ObjectType()
 @Entity()
 export class UserEducationFundState extends BaseEntity {
-  @Field((type) => Int, { nullable: false })
+  @Field((type) => Int)
   @PrimaryGeneratedColumn({ name: 'pk' })
   pk: number;
 
@@ -26,8 +27,13 @@ export class UserEducationFundState extends BaseEntity {
   @Column({ name: 'total_payment_of_money', nullable: false, default: 0 })
   total_payment_of_money: number;
 
-  @Field({ nullable: true })
-  @Column({ name: 'fund_period', nullable: true })
+  @Field({ nullable: false }) //data초기값이 설정안되어 있어서 추가
+  @Column({
+    name: 'fund_period',
+    nullable: false,
+    default: '9999-12-31',
+    type: 'date',
+  })
   fund_period: Date;
 
   @Field((type) => Int, { nullable: true })
@@ -38,17 +44,27 @@ export class UserEducationFundState extends BaseEntity {
   @Column({ name: 'total_calculated_month', nullable: false, default: 0 })
   total_calculated_month: number;
 
-  @Field({ nullable: true })
-  @Column({ name: 'payment_give_start_date', nullable: true })
+  @Field({ nullable: false }) //data초기값이 설정안되어 있어서 추가
+  @Column({
+    name: 'payment_give_start_date',
+    nullable: false,
+    default: '9999-12-31',
+    type: 'date',
+  })
   payment_give_start_date: Date;
 
   @Field((type) => Int, { nullable: true })
   @Column({ name: 'payment_delay_period', nullable: true })
   payment_delay_period: number;
 
-  @Field({ nullable: true })
-  @Column({ name: 'payment_give_break_date', nullable: true })
-  payment_give_break_date: Date;
+  @Field({ nullable: false }) //data초기값이 설정안되어 있어서 추가
+  @Column({
+    name: 'payment_end_date',
+    nullable: false,
+    default: '9999-12-31',
+    type: 'date',
+  })
+  payment_end_date: Date;
 
   @Field({ nullable: false })
   @CreateDateColumn({ name: 'created_date' })
@@ -59,5 +75,13 @@ export class UserEducationFundState extends BaseEntity {
   deleted_date: Date;
 
   @ManyToOne(() => User, (user) => user.userEducationFundState)
+  @Column({ name: 'fk_user_no', nullable: false })
+  fk_user_no: string;
+
+  @ManyToOne(() => User, (user) => user.userEducationFundState, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
+  @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }

--- a/packages/server/src/user_status/entity/user_status.entity.ts
+++ b/packages/server/src/user_status/entity/user_status.entity.ts
@@ -26,27 +26,45 @@ export class UserLearningData extends BaseEntity {
   @Column({ name: 'circle', nullable: true, default: 0 })
   circle: number;
 
-  @Field({ nullable: false, defaultValue: 0 })
+  @Field({ nullable: true })
+  @Column({
+    name: 'circle_date',
+    nullable: true,
+    default: '9999-12-31',
+    type: 'date',
+  })
+  circle_date: Date;
+
+  @Field({ nullable: true, defaultValue: 0 })
   @Column({
     type: 'float',
     name: 'level',
-    nullable: false,
+    nullable: true,
     default: 0,
   })
   level: number;
 
-  @Field({ nullable: false, defaultValue: 0 })
-  @Column({ name: 'coalition_score', nullable: false, default: 0 })
+  @Field({ nullable: true })
+  @Column({
+    name: 'level_date',
+    nullable: true,
+    default: '9999-12-31',
+    type: 'date',
+  })
+  level_date: Date;
+
+  @Field({ nullable: true, defaultValue: 0 })
+  @Column({ name: 'coalition_score', nullable: true, default: 0 }) //구글 스프레드 데이터에 없을 수도 있기 때문에 널이 올 수 있도록 처리하였습니다.
   coalition_score: number;
 
-  @Field({ nullable: true, defaultValue: 'N' }) //특정 데이터 때문에 널 허용중
+  @Field({ nullable: true, defaultValue: 'N' })
   @Column({ name: 'out_circle', nullable: true, default: 'N' })
   out_circle: string;
 
   @Field({ nullable: true })
   @Column({
     name: 'out_circle_date',
-    nullable: false,
+    nullable: true,
     default: '9999-12-31',
     type: 'date',
   })
@@ -60,10 +78,13 @@ export class UserLearningData extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userLearningDate)
+  @ManyToOne(() => User, (user) => user.userLearningDate, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }
@@ -106,10 +127,13 @@ export class UserProcessProgress extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userProcessProgress)
+  @ManyToOne(() => User, (user) => user.userProcessProgress, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }
@@ -147,10 +171,13 @@ export class UserBlackhole extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userBlackhole)
+  @ManyToOne(() => User, (user) => user.userBlackhole, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }
@@ -202,10 +229,13 @@ export class UserLeaveOfAbsence extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userLeaveOfAbsence)
+  @ManyToOne(() => User, (user) => user.userLeaveOfAbsence, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }
@@ -238,10 +268,13 @@ export class UserReasonOfBreak extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
-  fk_user_no: number;
+  @Column({ name: 'fk_user_no', nullable: false })
+  fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userReasonOfBreak)
+  @ManyToOne(() => User, (user) => user.userReasonOfBreak, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }
@@ -276,10 +309,13 @@ export class UserLapiscineInformation extends BaseEntity {
   @DeleteDateColumn()
   deleted_date: Date;
 
-  @Column({ name: 'fk_user_no', nullable: true })
+  @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @ManyToOne(() => User, (user) => user.userLapiscineInformation)
+  @ManyToOne(() => User, (user) => user.userLapiscineInformation, {
+    createForeignKeyConstraints: false, //외래키 제약조건 해제
+    nullable: false,
+  })
   @JoinColumn({ name: 'fk_user_no' })
   user: User;
 }


### PR DESCRIPTION
### 작업 동기 (Motivation)
- 하위시트를 파싱하기 위해 코드를 작성하였습니다.
- 커밋 충돌을 해결하기위해 수정하던 중, 멘토링을 통한 코드리뷰 후 복잡한 코드를 조금 더 간결하게 수정하였습니다.

### 변경 사항 요약 (Key changes)

첫번째 커밋 수정

- 하위시트를 파싱하기 위해 함수를 추가하였습니다.
- 기존 엔터티에 외래키 제약조건을 일부 해제하였습니다.
- 메인시트에 없던 컬럼들을 추가적으로 넣어 구성하였습니다.
- 기존 메인시트파싱이 유연하기 이뤄지지 않아, 테이블 구분 방식을 수정하였습니다.

충돌 이후 두번째 커밋


- 중복되는 함수 삭제 
- 하위시트 여러컬럼생성하는 부분 수정(같은 일자는 같은 로우)
- api로 데이터받아올 때, 스탭데이터만 받아와지는 오류 수정
- 충돌로 인해 생긴 오류 수정
- 변수 이름 변경
- 반복문의 중첩의 경우, 스프레드시트의 정보를 받아오는 특성때문에 고치지 못하였습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

