### PR TITLE
Feat/client/193

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "@apollo/client": "^3.6.9",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@mui/icons-material": "^5.8.4",
@@ -17,7 +18,9 @@
     "react-router-dom": "^6.0.5",
     "redux": "^4.2.0",
     "usehooks-ts": "^2.6.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "uuid": "^8.3.2",
+    "zustand": "^4.0.0-rc.1"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -74,6 +77,8 @@
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "@types/react-grid-layout": "^1.3.2",
+    "@types/uuid": "^8.3.4",
+    "@types/chart.js": "^2.9.37",
     "@typescript-eslint/eslint-plugin": "*",
     "@typescript-eslint/parser": "*",
     "eslint": "*",

--- a/packages/client/src/dashboard/application/services/useDataset.tsx
+++ b/packages/client/src/dashboard/application/services/useDataset.tsx
@@ -1,0 +1,18 @@
+import { DocumentNode, useQuery } from '@apollo/client';
+
+export interface QueryDataType {
+  query: DocumentNode;
+  filters: object;
+}
+
+function useChartDataset(queryData: QueryDataType) {
+  const { query, filters } = queryData;
+
+  const { data, loading, error } = useQuery(query, {
+    variables: filters,
+  });
+
+  return { data, loading, error };
+}
+
+export default useChartDataset;

--- a/packages/client/src/dashboard/infrastructure/http/graphql/createQuery.ts
+++ b/packages/client/src/dashboard/infrastructure/http/graphql/createQuery.ts
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client';
+
+export default function createQuery(
+  filterNames: string[],
+  labels: string[],
+  filterSets: string[][],
+) {
+  return gql`
+    query GetDatasets(
+      ${filterNames.map((filterName) => `$${filterName}: Filter!`).join('\n')}
+    ) {
+     ${filterSets
+       .map((filterSet, index) => {
+         const alias = `${labels[index % labels.length]}${Math.floor(
+           index / labels.length,
+         )}`;
+         const queryName = `getNumOfPeopleByFilter`;
+         const filters = `filters: [${filterSet
+           .map((filterName) => `$${filterName}`)
+           .join(', ')}]`;
+         return `${alias}: ${queryName}(${filters})`;
+       })
+       .join('\n')}
+      }`;
+}

--- a/packages/client/src/dashboard/presentation/components/Charts/BarChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/BarChart.tsx
@@ -1,14 +1,29 @@
 import { Bar } from 'react-chartjs-2';
 import { Chart, registerables } from 'chart.js';
-import { data, options } from './ChartData';
-import { ChartProps } from './Chart.stories';
+import { ChartProps } from './ChartData';
+import useChartDataset from '../../../application/services/useDataset';
+
 Chart.register(...registerables);
 
-/* Code For Storybook */
-export function StoryBarChart(props: ChartProps) {
-  return <Bar data={props.data} options={props.options} />;
-}
+export default function BarChart(props: ChartProps) {
+  const { labels, queryData, options } = props;
+  const { data, loading, error } = useChartDataset(queryData);
+  const datasets = [];
 
-export default function BarChart() {
-  return <Bar data={data} options={options} />;
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error :(</p>;
+
+  const dataArray = Object.values(data);
+  while (dataArray.length > 0) {
+    datasets.push(dataArray.splice(0, labels.length));
+  }
+  const barData = {
+    labels,
+    datasets: datasets.map((dataset) => ({
+      data: dataset,
+      backgroundColor: ['#36A2EB', '#FF6384'],
+    })),
+  };
+
+  return <Bar data={barData} options={options} />;
 }

--- a/packages/client/src/dashboard/presentation/components/Charts/ChartData.ts
+++ b/packages/client/src/dashboard/presentation/components/Charts/ChartData.ts
@@ -1,3 +1,6 @@
+import { ChartOptions } from 'chart.js';
+import { QueryDataType } from '../../../application/services/useDataset';
+
 export const chartColor = [
   '#72aee6',
   '#c3c4c7',
@@ -44,3 +47,9 @@ export const options = {
   responsive: true,
   maintainAspectRatio: false,
 };
+
+export interface ChartProps {
+  labels: string[];
+  queryData: QueryDataType;
+  options?: ChartOptions;
+}

--- a/packages/client/src/dashboard/presentation/components/Charts/LineChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/LineChart.tsx
@@ -1,14 +1,29 @@
 import { Line } from 'react-chartjs-2';
 import { Chart, registerables } from 'chart.js';
-import { data, options } from './ChartData';
-import { ChartProps } from './Chart.stories';
+import { ChartProps } from './ChartData';
+import useChartDataset from '../../../application/services/useDataset';
+
 Chart.register(...registerables);
 
-/* Code For Storybook */
-export function StoryLineChart(props: ChartProps) {
-  return <Line data={props.data} options={props.options} />;
-}
+export default function LineChart(props: ChartProps) {
+  const { labels, queryData, options } = props;
+  const { data, loading, error } = useChartDataset(queryData);
+  const datasets = [];
 
-export default function LineChart() {
-  return <Line data={data} options={options} />;
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error :(</p>;
+
+  const dataArray = Object.values(data);
+  while (dataArray.length > 0) {
+    datasets.push(dataArray.splice(0, labels.length));
+  }
+  const lineData = {
+    labels,
+    datasets: datasets.map((dataset) => ({
+      data: dataset,
+      backgroundColor: ['#36A2EB', '#FF6384'],
+    })),
+  };
+
+  return <Line data={lineData} options={options} />;
 }

--- a/packages/client/src/dashboard/presentation/components/Charts/PieChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/PieChart.tsx
@@ -1,14 +1,30 @@
 import { Pie } from 'react-chartjs-2';
 import { Chart, registerables } from 'chart.js';
-import { data, options } from './ChartData';
-import { ChartProps } from './Chart.stories';
+import useChartDataset from '../../../application/services/useDataset';
+import { ChartProps } from './ChartData';
+
 Chart.register(...registerables);
 
-/* Code For Storybook */
-export function StoryPieChart(props: ChartProps) {
-  return <Pie data={props.data} options={props.options} />;
-}
+export default function PieChart(props: ChartProps) {
+  const { labels, queryData, options } = props;
+  const { data, loading, error } = useChartDataset(queryData);
+  const datasets = [];
 
-export default function PieChart() {
-  return <Pie data={data} options={options} />;
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error :(</p>;
+
+  const dataArray = Object.values(data);
+  while (dataArray.length > 0) {
+    datasets.push(dataArray.splice(0, labels.length));
+  }
+  const pieData = {
+    labels,
+    datasets: datasets.map((dataset) => ({
+      label: 'Test',
+      data: dataset,
+      backgroundColor: ['#36A2EB', '#FF6384'],
+    })),
+  };
+
+  return <Pie data={pieData} options={options} />;
 }

--- a/packages/client/src/dashboard/presentation/components/Sticker/StickerContent.type.ts
+++ b/packages/client/src/dashboard/presentation/components/Sticker/StickerContent.type.ts
@@ -1,0 +1,89 @@
+import {
+  BarControllerChartOptions,
+  ChartData,
+  CoreChartOptions,
+  DatasetChartOptions,
+  DoughnutControllerChartOptions,
+  ElementChartOptions,
+  LineControllerChartOptions,
+  PluginChartOptions,
+  ScaleChartOptions,
+} from 'chart.js';
+
+import { _DeepPartialObject } from 'chart.js/types/utils';
+import { ChartProps } from '../Charts/ChartData';
+
+export interface StickerContent {
+  pieChart: PieChartStickerType;
+  lineChart: LineChartStickerType;
+  barChart: BarChartStickerType;
+  text: TextStickerType;
+  table: TableStickerType;
+}
+
+export type StickerContentType = Extract<keyof StickerContent, string>;
+
+interface PieChartStickerType {
+  data: ChartData<'pie', number[], string>;
+  options?:
+    | _DeepPartialObject<
+        CoreChartOptions<'pie'> &
+          ElementChartOptions<'pie'> &
+          PluginChartOptions<'pie'> &
+          DatasetChartOptions<'pie'> &
+          ScaleChartOptions<'pie'> &
+          DoughnutControllerChartOptions
+      >
+    | undefined;
+}
+
+interface LineChartStickerType {
+  data: ChartData<'line', number[], string>;
+  options?:
+    | _DeepPartialObject<
+        CoreChartOptions<'line'> &
+          ElementChartOptions<'line'> &
+          PluginChartOptions<'line'> &
+          DatasetChartOptions<'line'> &
+          ScaleChartOptions<'line'> &
+          LineControllerChartOptions
+      >
+    | undefined;
+}
+
+interface BarChartStickerType {
+  data: ChartData<'bar', number[], string>;
+  options?:
+    | _DeepPartialObject<
+        CoreChartOptions<'bar'> &
+          ElementChartOptions<'bar'> &
+          PluginChartOptions<'bar'> &
+          DatasetChartOptions<'bar'> &
+          ScaleChartOptions<'bar'> &
+          BarControllerChartOptions
+      >
+    | undefined;
+}
+
+interface TableStickerType {
+  something: string;
+}
+
+interface TextStickerType {
+  content: string;
+}
+
+export type StickerContentPropType = ChartProps;
+
+// [getNumOfPeopleByFilter(filters: [$filtersGrade, $filtersMan]), getNumOfPeopleByFilter(filters: [$filtersGrade, $filtersWoman]),  ]
+// labels : 데이터 세트의 각 데이터에 매치되는 라벨의 배열
+// datasets: 데이터 세트의 배열
+// [ {
+// 	label: 데이터 세트의 라벨
+// 	data: 라벨 배열과 인덱스로 매칭되는 데이터 배열.
+// }
+// ]
+
+// 라벨 하나당 일치하는 쿼리 + 필터 배열 => 데이터 하나 레시피
+
+// dataset => [242, 24];

--- a/packages/client/src/dashboard/presentation/components/Sticker/StickerContentFactory.tsx
+++ b/packages/client/src/dashboard/presentation/components/Sticker/StickerContentFactory.tsx
@@ -1,0 +1,32 @@
+import PieChart from '../Charts/PieChart';
+import {
+  StickerContentPropType,
+  StickerContentType,
+} from './StickerContent.type';
+import LineChart from '../Charts/LineChart';
+import BarChart from '../Charts/BarChart';
+
+export interface StickerContentFactoryProps {
+  type: StickerContentType;
+  contentProps: StickerContentPropType;
+}
+
+function StickerContentFactory(props: StickerContentFactoryProps) {
+  const { type, contentProps } = props;
+  switch (type) {
+    case 'pieChart':
+      return <PieChart {...contentProps} />;
+    case 'lineChart':
+      return <LineChart {...contentProps} />;
+    case 'barChart':
+      return <BarChart {...contentProps} />;
+    case 'text':
+      return <div>개발 중</div>;
+    case 'table':
+      return <div>개발 중</div>;
+    default:
+      return <div>개발 중</div>;
+  }
+}
+
+export default StickerContentFactory;

--- a/packages/client/src/dashboard/presentation/pages/DashBoardPage.tsx
+++ b/packages/client/src/dashboard/presentation/pages/DashBoardPage.tsx
@@ -1,51 +1,92 @@
 import { Box, CssBaseline, Typography } from '@mui/material';
+import createQuery from '../../infrastructure/http/graphql/createQuery';
 import AppBar from '../components/AppBar/AppBar';
 import ProfileMenu from '../components/AppBar/ProfileMenu/ProfileMenu';
-import Board from '../components/Board/Board';
+import BarChart from '../components/Charts/BarChart';
+import LineChart from '../components/Charts/LineChart';
+import PieChart from '../components/Charts/PieChart';
 import MainArea from '../components/MainArea/MainArea';
 import ModeDial from '../components/ModeDial/ModeDial';
 import SideBar from '../components/SideBar/SideBar';
 
-const appBarTitle = (
-  <Typography
-    variant="h6"
-    component="a"
-    href="/"
-    sx={{
-      mr: 2,
-      fontFamily: 'monospace',
-      fontWeight: 700,
-      letterSpacing: '.3rem',
-      color: 'inherit',
-      textDecoration: 'none',
-    }}
-    noWrap
-  >
-    AppBarTitle
-  </Typography>
-);
-
-const profile = { name: 'kilee', size: 48 };
-
-const profileMenuItems = [
-  {
-    label: '마이페이지',
-    onClick: () => {
-      console.log('Click');
-    },
-  },
-  {
-    label: '로그아웃',
-    onClick: () => {
-      console.log('로그아웃');
-    },
-  },
-];
-const profileMenu = (
-  <ProfileMenu menuItems={profileMenuItems} profile={profile} />
-);
-
 function DashBoardPage() {
+  const appBarTitle = (
+    <Typography
+      variant="h6"
+      component="a"
+      href="/"
+      sx={{
+        mr: 2,
+        fontFamily: 'monospace',
+        fontWeight: 700,
+        letterSpacing: '.3rem',
+        color: 'inherit',
+        textDecoration: 'none',
+      }}
+      noWrap
+    >
+      42Dash
+    </Typography>
+  );
+
+  const profile = { name: 'kilee', size: 48 };
+
+  const profileMenuItems = [
+    {
+      label: '마이페이지',
+      onClick: () => {
+        console.log('Click');
+      },
+    },
+    {
+      label: '로그아웃',
+      onClick: () => {
+        console.log('로그아웃');
+      },
+    },
+  ];
+
+  const profileMenu = (
+    <ProfileMenu menuItems={profileMenuItems} profile={profile} />
+  );
+
+  const weMadeQuery = createQuery(
+    ['filtersGrade', 'filtersMan', 'filtersWoman'],
+    ['man', 'woman'],
+    [
+      ['filtersGrade', 'filtersMan'],
+      ['filtersGrade', 'filtersWoman'],
+      ['filtersMan'],
+      ['filtersWoman'],
+    ],
+  );
+  const queryData = {
+    query: weMadeQuery,
+    filters: {
+      filtersMan: {
+        entityName: 'userPersonalInformation',
+        column: 'gender',
+        operator: '=',
+        givenValue: '남',
+        latest: true,
+      },
+      filtersWoman: {
+        entityName: 'userPersonalInformation',
+        column: 'gender',
+        operator: '=',
+        givenValue: '여',
+        latest: true,
+      },
+      filtersGrade: {
+        entityName: 'user',
+        column: 'grade',
+        operator: '=',
+        givenValue: '2기',
+        latest: true,
+      },
+    },
+  };
+
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
@@ -56,7 +97,9 @@ function DashBoardPage() {
       </AppBar>
       <SideBar />
       <MainArea>
-        <Board />
+        <PieChart labels={['man', 'woman']} queryData={queryData} />
+        <LineChart labels={['man', 'woman']} queryData={queryData} />
+        <BarChart labels={['man', 'woman']} queryData={queryData} />
       </MainArea>
       <ModeDial />
     </Box>

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -5,18 +5,26 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import store from './dashboard/infrastructure/redux/store';
+import store from './dashboard/infrastructure/store/redux/store';
+import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
+
+const client = new ApolloClient({
+  uri: 'https://d001-121-135-181-61.jp.ngrok.io/graphql',
+  cache: new InMemoryCache(),
+});
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
 root.render(
   <React.StrictMode>
-    <Provider store={store}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </Provider>
+    <ApolloProvider client={client}>
+      <Provider store={store}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </Provider>
+    </ApolloProvider>
   </React.StrictMode>,
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,24 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
+"@apollo/client@^3.6.9":
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.9.tgz#ad0ee2e3a3c92dbed4acd6917b6158a492739d94"
+  integrity sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/context" "^0.6.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.1"
+    prop-types "^15.7.2"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
 "@apollo/protobufjs@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.2.tgz#4bd92cd7701ccaef6d517cdb75af2755f049f87c"
@@ -1837,6 +1855,11 @@
   integrity sha512-KJrtx05uSM/cPYFdTnGAS1doL5bftJLAiFCDMZ8Vkifztz3BFn3gpFiy/o4wDtM8s39G46mxmt2Km/RmeltfGw==
   dependencies:
     tslib "^2.4.0"
+
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
@@ -4025,6 +4048,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/chart.js@^2.9.37":
+  version "2.9.37"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.37.tgz#8af70862b154fedf938b5b87debdb3a70f6e3208"
+  integrity sha512-9bosRfHhkXxKYfrw94EmyDQcdjMaQPkU1fH2tDxu8DWXxf1mjzWQAV4laJF51ZbC2ycYwNDvIm1rGez8Bug0vg==
+  dependencies:
+    moment "^2.10.2"
+
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
@@ -4501,6 +4531,11 @@
   resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
   integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/webpack-env@^1.16.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.17.0.tgz#f99ce359f1bfd87da90cc4a57cab0a18f34a48d0"
@@ -4955,6 +4990,27 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@wry/context@^0.6.0":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
+  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.2.tgz#72c8a7a7d884dff30b612f4f8464eba26c080e73"
+  integrity sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.1.tgz#2279b790f15032f8bcea7fc944d27988e5b3b139"
+  integrity sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==
+  dependencies:
+    tslib "^2.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -9507,7 +9563,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graphql-tag@2.12.6, graphql-tag@^2.11.0:
+graphql-tag@2.12.6, graphql-tag@^2.11.0, graphql-tag@^2.12.6:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
   integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
@@ -12624,6 +12680,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.10.2:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -13082,6 +13143,14 @@ open@^8.0.9, open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+optimism@^0.16.1:
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.1.tgz#7c8efc1f3179f18307b887e18c15c5b7133f6e7d"
+  integrity sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==
+  dependencies:
+    "@wry/context" "^0.6.0"
+    "@wry/trie" "^0.3.0"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -16473,7 +16542,7 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
-symbol-observable@4.0.0:
+symbol-observable@4.0.0, symbol-observable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
   integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
@@ -16847,6 +16916,13 @@ ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
+
 ts-jest@28.0.1:
   version "28.0.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.1.tgz#626b4d7d5c386f88f4813d959ffc4ca0a8ffef96"
@@ -16923,7 +16999,7 @@ tsconfig-paths@4.0.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.4.0, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@~2.4.0:
+tslib@2.4.0, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
@@ -17270,6 +17346,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-sync-external-store@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
+  integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
 use-sync-external-store@^1.0.0:
   version "1.2.0"
@@ -18190,6 +18271,25 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
+
+zustand@^4.0.0-rc.1:
+  version "4.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.0.0-rc.1.tgz#ec30a3afc03728adec7e1bd7bcc3592176372201"
+  integrity sha512-qgcs7zLqBdHu0PuT3GW4WCIY5SgXdsv30GQMu9Qpp1BA2aS+sNS8l4x0hWuyEhjXkN+701aGWawhKDv6oWJAcw==
+  dependencies:
+    use-sync-external-store "1.1.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
### 작업 동기 (Motivation)

- Sticker 컨테이너 내부의 StickerContent는 여러가지 타입(Chart | Table | Text 등)이 올 수 있기 때문에, Factory 패턴을 사용할 필요가 있다 판단했습니다. 

### 변경 사항 요약 (Key changes)

- `StickerContentFactory` 컴포넌트를 작성 :  `props.type` 에 따라 적절한 컴포넌트를 리턴해주는 팩토리 컴포넌트
- `useDataset` 커스텀 훅 작성 : `qeuryData` 를 인자로 받아서 Chart에 적용하는 data을 가져오는 로직을 커스텀 훅으로 작성하여 차트들에서 공통적으로 사용할 수 있도록 하였습니다. 
- `Pie/Line/BarChart` 컴포넌트 수정 : `useDataset` 훅을 사용하여 받아온 gql response data를 차트에 적용할 수 있는 형태의 datasets로 가공하여 이를 그릴 수 있도록 수정했습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

