### PR TITLE
fix(server/updater): fixed: fix entity relation

### DIFF
--- a/packages/server/src/user_information/entity/user_access_card_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_access_card_information.entity.ts
@@ -6,6 +6,7 @@ import {
   DeleteDateColumn,
   Entity,
   JoinColumn,
+  ManyToOne,
   OneToOne,
   PrimaryColumn,
   PrimaryGeneratedColumn,
@@ -53,7 +54,7 @@ export class UserAccessCardInformation extends BaseEntity {
   @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string;
 
-  @OneToOne(() => User, (user) => user.userAccessCardInformation, {
+  @ManyToOne(() => User, (user) => user.userAccessCardInformation, {
     createForeignKeyConstraints: false, //외래키 제약조건 해제
     nullable: false,
   })

--- a/packages/server/src/user_information/entity/user_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_information.entity.ts
@@ -91,7 +91,7 @@ export class User {
    ***********************************/
 
   // @Field()
-  @OneToOne(
+  @OneToMany(
     () => UserPersonalInformation,
     (userPersonalInformation) => userPersonalInformation.user,
     { cascade: true },
@@ -99,7 +99,7 @@ export class User {
   userPersonalInformation: UserPersonalInformation;
 
   // @Field(()=>UserAccessCardInformation)
-  @OneToOne(
+  @OneToMany(
     () => UserAccessCardInformation,
     (userAccessCardInformation) => userAccessCardInformation.user,
     { cascade: true },

--- a/packages/server/src/user_information/entity/user_personal_information.entity.ts
+++ b/packages/server/src/user_information/entity/user_personal_information.entity.ts
@@ -6,6 +6,7 @@ import {
   DeleteDateColumn,
   Entity,
   JoinColumn,
+  ManyToOne,
   OneToOne,
   PrimaryColumn,
   PrimaryGeneratedColumn,
@@ -51,7 +52,7 @@ export class UserPersonalInformation {
   @Column({ name: 'fk_user_no', nullable: false })
   fk_user_no: string; //외래키값을 선언하지 않으면 null으로 판단됨
 
-  @OneToOne(() => User, (user) => user.userPersonalInformation, {
+  @ManyToOne(() => User, (user) => user.userPersonalInformation, {
     createForeignKeyConstraints: false, //외래키 제약조건 해제
     nullable: false,
   })


### PR DESCRIPTION
personal & accesscard 엔티티 관계 수정

fix #208

### 작업 동기 (Motivation)
entity 수정

### 변경 사항 요약 (Key changes)
user_personal_infomation
user_access_card_information
의 관계를 one to one 에서 many to one으로 변경

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

