### PR TITLE
feat(mode): ControlMode에 따른 EditToolBar 렌더링

### DIFF
--- a/packages/client/src/dashboard/application/services/useBoard.tsx
+++ b/packages/client/src/dashboard/application/services/useBoard.tsx
@@ -36,7 +36,8 @@ function useBoard() {
       info: preset.info,
     });
   };
-  const handleSectionAdd = (sectionId: string) => {
+  const handleSectionAdd = (sectionId: string | undefined) => {
+    if (sectionId === undefined) return;
     const newLayout = [
       ...boardData.sectionLayouts,
       {

--- a/packages/client/src/dashboard/application/services/useMode.tsx
+++ b/packages/client/src/dashboard/application/services/useMode.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import ControlModeService from '../../domain/controlMode/controlMode.service';
+import ControlModeType from '../../domain/controlMode/controlMode.type';
+import ControlModeRepository from '../../infrastructure/controlMode.repository';
+import ControlModeStore from '../../infrastructure/store/controlMode.store';
+
+const controlModeService = new ControlModeService(ControlModeRepository);
+
+function useMode() {
+  const [controlModeData, setcontrolModeData] = useState(
+    ControlModeStore.getControlMode(),
+  );
+
+  console.log('stateMode : ', controlModeData);
+
+  ControlModeStore.subscribeToControlMode(
+    (newControlModeData: ControlModeType) => {
+      setcontrolModeData(newControlModeData);
+    },
+  );
+
+  const getControlMode = () => {
+    return controlModeService.getControlMode();
+  };
+
+  const setControlMode = async (mode: ControlModeType) => {
+    return await controlModeService.setControlMode(mode);
+  };
+
+  return { controlModeData, getControlMode, setControlMode };
+}
+
+export default useMode;

--- a/packages/client/src/dashboard/application/services/useSectionDatas.tsx
+++ b/packages/client/src/dashboard/application/services/useSectionDatas.tsx
@@ -19,7 +19,8 @@ function useSections() {
     },
   );
 
-  const addSectionData = (sectionDatas: SectionDataType) => {
+  const addSectionData = (sectionDatas: SectionDataType | undefined) => {
+    if (sectionDatas === undefined) return;
     return sectionDatasService.addSectionData(sectionDatas);
   };
 

--- a/packages/client/src/dashboard/domain/controlMode/controlMode.repository.interface.ts
+++ b/packages/client/src/dashboard/domain/controlMode/controlMode.repository.interface.ts
@@ -1,7 +1,7 @@
 import ControlModeType from './controlMode.type';
 
 interface ControlModeRepositoryInterface {
-  getControlMode(): Promise<ControlModeType>;
+  getControlMode(): string;
   setControlMode(controlMode: ControlModeType): Promise<void>;
 }
 

--- a/packages/client/src/dashboard/domain/controlMode/controlMode.service.ts
+++ b/packages/client/src/dashboard/domain/controlMode/controlMode.service.ts
@@ -6,7 +6,7 @@ class ControlModeService {
     protected controlModeRepository: ControlModeRepositoryInterface,
   ) {}
 
-  public async getControlMode(): Promise<ControlModeType> {
+  public getControlMode(): string {
     return this.controlModeRepository.getControlMode();
   }
 

--- a/packages/client/src/dashboard/infrastructure/controlMode.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/controlMode.repository.ts
@@ -3,7 +3,7 @@ import ControlModeType from '../domain/controlMode/controlMode.type';
 import controlModeStore from './store/controlMode.store';
 
 class ControlModeRepository implements ControlModeRepositoryInterface {
-  public async getControlMode(): Promise<ControlModeType> {
+  public getControlMode(): string {
     return controlModeStore.getControlMode();
   }
 

--- a/packages/client/src/dashboard/presentation/components/Board/Board.tsx
+++ b/packages/client/src/dashboard/presentation/components/Board/Board.tsx
@@ -5,9 +5,11 @@ import Section from './Section';
 import PresetType from '../../../domain/preset/preset.type';
 import useSections from '../../../application/services/useSectionDatas';
 import useBoard from '../../../application/services/useBoard';
+import useMode from '../../../application/services/useMode';
 import { v4 as uuid } from 'uuid';
 import SectionDataType from '../../../domain/sectionDatas/sectionData.type';
 import { Button } from '@mui/material';
+import EditToolBar from '../Common/EditToolBar';
 
 const ReactGridLayout = WidthProvider(RGL.Responsive);
 
@@ -32,6 +34,8 @@ export default function Board() {
     handleSectionRemove,
     handleSavePreset,
   } = useBoard();
+
+  const { getControlMode } = useMode();
 
   const sectionData: SectionDataType = {
     id: uuid(),
@@ -64,14 +68,13 @@ export default function Board() {
 
   return (
     <>
-      <Button
-        onClick={() => {
-          addSectionData(sectionData);
-          handleSectionAdd(sectionData.id);
-        }}
-      >
-        Add Section Item
-      </Button>
+      {getControlMode() === 'edit' && (
+        <EditToolBar
+          type="Board"
+          sectionData={sectionData}
+          sectionId={sectionData.id}
+        />
+      )}
       <Button
         onClick={() => {
           handleSavePreset();

--- a/packages/client/src/dashboard/presentation/components/Board/Board.tsx
+++ b/packages/client/src/dashboard/presentation/components/Board/Board.tsx
@@ -75,13 +75,6 @@ export default function Board() {
           sectionId={sectionData.id}
         />
       )}
-      <Button
-        onClick={() => {
-          handleSavePreset();
-        }}
-      >
-        프리셋 저장
-      </Button>
       <ReactGridLayout
         onDragStart={(a, b, c, d, e) => e.stopPropagation()}
         layouts={{ lg: boardData.sectionLayouts || [] }}

--- a/packages/client/src/dashboard/presentation/components/Board/Section.tsx
+++ b/packages/client/src/dashboard/presentation/components/Board/Section.tsx
@@ -2,10 +2,14 @@ import './styles.css';
 import './styles2.css';
 import Sticker from '../Sticker/Sticker';
 import useStickers from '../../../application/services/useStickers';
+import useMode from '../../../application/services/useMode';
 import { Button } from '@mui/material';
 import RGL, { Layout, WidthProvider } from 'react-grid-layout';
 import ModalFrame from '../Modal/Modal';
 import { useState } from 'react';
+import HorizontalLinearStepper from '../Modal/Stepper';
+import makeStickerData from '../Modal/makeStickerData';
+import EditToolBar from '../Common/EditToolBar';
 
 const ReactGridLayout = WidthProvider(RGL.Responsive);
 
@@ -29,6 +33,8 @@ export default function Section(props: SectionProps) {
     handleStickerRemove,
   } = props;
   const [isOpen, setIsOpen] = useState(false);
+  const { getControlMode } = useMode();
+
   function drawStickers() {
     return stickerLayouts.map((sticker: Layout, idx) => (
       <div key={sticker.i}>
@@ -47,6 +53,9 @@ export default function Section(props: SectionProps) {
   return (
     <>
       <Button onClick={() => setIsOpen(false)}>Add Sticker</Button>
+      {getControlMode() === 'edit' && (
+        <EditToolBar type="Section" setIsOpen={setIsOpen} />
+      )}
       <ModalFrame
         isOpen={isOpen}
         setIsOpen={setIsOpen}

--- a/packages/client/src/dashboard/presentation/components/Board/Section.tsx
+++ b/packages/client/src/dashboard/presentation/components/Board/Section.tsx
@@ -52,9 +52,13 @@ export default function Section(props: SectionProps) {
 
   return (
     <>
-      <Button onClick={() => setIsOpen(false)}>Add Sticker</Button>
       {getControlMode() === 'edit' && (
-        <EditToolBar type="Section" setIsOpen={setIsOpen} />
+        <EditToolBar
+          type="Section"
+          setIsOpen={setIsOpen}
+          removeItem={handleSectionRemove}
+          id={id}
+        />
       )}
       <ModalFrame
         isOpen={isOpen}

--- a/packages/client/src/dashboard/presentation/components/Common/EditToolBar.tsx
+++ b/packages/client/src/dashboard/presentation/components/Common/EditToolBar.tsx
@@ -12,6 +12,8 @@ interface EditToolBarProps {
   sectionData?: SectionDataType | undefined;
   sectionId?: string | undefined;
   setIsOpen?: ((isOpen: boolean) => void) | undefined;
+  removeItem?: ((id: string) => void) | undefined;
+  id?: string;
 }
 
 const EditToolBarArea = styled.div`
@@ -29,7 +31,7 @@ const EditToolBarArea = styled.div`
 const EditToolBar = (props: EditToolBarProps) => {
   const { addSectionData } = useSections();
   const { handleSectionAdd, handleSavePreset } = useBoard();
-  const { type, sectionData, sectionId, setIsOpen } = props;
+  const { type, sectionData, sectionId, setIsOpen, removeItem, id } = props;
 
   return (
     <EditToolBarArea>
@@ -48,10 +50,20 @@ const EditToolBar = (props: EditToolBarProps) => {
           Add Sticekr
         </Button>
       )}
+      {type === 'Sticker' && <Button>Apply Filter</Button>}
       {type === 'Board' && (
         <Button onClick={() => handleSavePreset()}>Save Preset</Button>
       )}
-      {type === 'Section' && <Button>Remove</Button>}
+      {type === 'Section' && (
+        <Button onClick={() => removeItem && id && removeItem(id)}>
+          Remove
+        </Button>
+      )}
+      {type === 'Sticker' && (
+        <Button onClick={() => removeItem && id && removeItem(id)}>
+          Remove
+        </Button>
+      )}
     </EditToolBarArea>
   );
 };

--- a/packages/client/src/dashboard/presentation/components/Common/EditToolBar.tsx
+++ b/packages/client/src/dashboard/presentation/components/Common/EditToolBar.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import useSections from '../../../application/services/useSectionDatas';
+import useBoard from '../../../application/services/useBoard';
+import SectionDataType from '../../../domain/sectionDatas/sectionData.type';
+import { Button } from '@mui/material';
+
+type ToolType = 'Board' | 'Section' | 'Sticker';
+
+interface EditToolBarProps {
+  type: ToolType;
+  sectionData?: SectionDataType | undefined;
+  sectionId?: string | undefined;
+  setIsOpen?: ((isOpen: boolean) => void) | undefined;
+}
+
+const EditToolBarArea = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  border: 1px solid blue;
+`;
+
+// TODO: hybae
+// Section - Remove Section 추가
+// Sticker - Apply Filter 추가
+// Sticker - Remove Sticker 추가
+
+const EditToolBar = (props: EditToolBarProps) => {
+  const { addSectionData } = useSections();
+  const { handleSectionAdd, handleSavePreset } = useBoard();
+  const { type, sectionData, sectionId, setIsOpen } = props;
+
+  return (
+    <EditToolBarArea>
+      {type === 'Board' && (
+        <Button
+          onClick={() => {
+            addSectionData(sectionData);
+            handleSectionAdd(sectionId);
+          }}
+        >
+          Add Section
+        </Button>
+      )}
+      {type === 'Section' && (
+        <Button onClick={() => setIsOpen && setIsOpen(true)}>
+          Add Sticekr
+        </Button>
+      )}
+      {type === 'Board' && (
+        <Button onClick={() => handleSavePreset()}>Save Preset</Button>
+      )}
+      {type === 'Section' && <Button>Remove</Button>}
+    </EditToolBarArea>
+  );
+};
+export default EditToolBar;

--- a/packages/client/src/dashboard/presentation/components/ModeDial/ModeDial.tsx
+++ b/packages/client/src/dashboard/presentation/components/ModeDial/ModeDial.tsx
@@ -6,17 +6,10 @@ import SpeedDialAction from '@mui/material/SpeedDialAction';
 import IosShareIcon from '@mui/icons-material/IosShare';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import ModeEditIcon from '@mui/icons-material/ModeEdit';
-
-import { boardModeActions } from '../../../infrastructure/store/redux/actions';
-import {
-  useAppDispatch,
-  useAppSelector,
-} from '../../../infrastructure/store/redux/hooks';
+import useMode from '../../../application/services/useMode';
 
 export default function ModeDial() {
-  const dispatch = useAppDispatch();
-  const mode = useAppSelector((state) => state.mode);
-  console.log(mode);
+  const { setControlMode } = useMode();
   return (
     <Box
       sx={{
@@ -33,21 +26,21 @@ export default function ModeDial() {
           icon={<ModeEditIcon />}
           tooltipTitle={'EditMode'}
           onClick={() => {
-            dispatch(boardModeActions.changeMode('edit'));
+            setControlMode('edit');
           }}
         />
         <SpeedDialAction
           icon={<FullscreenIcon />}
           tooltipTitle={'Fullscreen'}
           onClick={() => {
-            dispatch(boardModeActions.changeMode('fullscreen'));
+            setControlMode('fullscreen');
           }}
         />
         <SpeedDialAction
           icon={<IosShareIcon />}
           tooltipTitle={'Export'}
           onClick={() => {
-            dispatch(boardModeActions.changeMode('export'));
+            setControlMode('export');
           }}
         />
       </SpeedDial>

--- a/packages/client/src/dashboard/presentation/components/Sticker/Sticker.tsx
+++ b/packages/client/src/dashboard/presentation/components/Sticker/Sticker.tsx
@@ -1,7 +1,9 @@
 import StickerContentFactory, {
   StickerContentFactoryProps,
 } from './StickerContentFactory';
+import useMode from '../../../application/services/useMode';
 import { Button } from '@mui/material';
+import EditToolBar from '../Common/EditToolBar';
 
 interface StickerProps {
   id: string;
@@ -11,10 +13,12 @@ interface StickerProps {
 
 function Sticker(props: StickerProps) {
   const { id, data, handleStickerRemove } = props;
-
+  const { getControlMode } = useMode();
   return (
     <>
-      <Button onClick={() => handleStickerRemove(id)}>Remove Sticker</Button>
+      {getControlMode() === 'edit' && (
+        <EditToolBar type="Sticker" removeItem={handleStickerRemove} id={id} />
+      )}
       <StickerContentFactory
         type={data.type}
         contentProps={data.contentProps}


### PR DESCRIPTION
### 작업 동기 (Motivation)
- ControlMode 중, edit 모드의 경우에만 보드, 섹션, 스티커를 컨트롤 할 수 있는 EditToolBar가 보이도록 작업

### 변경 사항 요약 (Key changes)
- 기존에 모드 변경을 위해 적용된 redux를 PAID 구조에 맞춰 변경
- Board 내 Add Section, Save Preset 적용
- Section 내 Add Sticker 적용

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

