### PR TITLE
feat(sticker): feat: Sticker 내 Component 크기 제한

### DIFF
--- a/packages/client/src/dashboard/presentation/components/Charts/BarChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/BarChart.tsx
@@ -9,6 +9,10 @@ export default function BarChart(props: ChartProps) {
   const { labels, queryData, options } = props;
   const { data, loading, error } = useChartDataset(queryData);
   const datasets = [];
+  const defaultOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+  };
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error :(</p>;
@@ -25,5 +29,12 @@ export default function BarChart(props: ChartProps) {
     })),
   };
 
-  return <Bar data={barData} options={options} />;
+  return (
+    <Bar
+      data={barData}
+      options={
+        options ? Object.assign(defaultOptions, options) : defaultOptions
+      }
+    />
+  );
 }

--- a/packages/client/src/dashboard/presentation/components/Charts/LineChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/LineChart.tsx
@@ -9,6 +9,10 @@ export default function LineChart(props: ChartProps) {
   const { labels, queryData, options } = props;
   const { data, loading, error } = useChartDataset(queryData);
   const datasets = [];
+  const defaultOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+  };
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error :(</p>;
@@ -25,5 +29,12 @@ export default function LineChart(props: ChartProps) {
     })),
   };
 
-  return <Line data={lineData} options={options} />;
+  return (
+    <Line
+      data={lineData}
+      options={
+        options ? Object.assign(defaultOptions, options) : defaultOptions
+      }
+    />
+  );
 }

--- a/packages/client/src/dashboard/presentation/components/Charts/PieChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/PieChart.tsx
@@ -9,6 +9,10 @@ export default function PieChart(props: ChartProps) {
   const { labels, queryData, options } = props;
   const { data, loading, error } = useChartDataset(queryData);
   const datasets = [];
+  const defaultOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+  };
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error :(</p>;
@@ -26,5 +30,12 @@ export default function PieChart(props: ChartProps) {
     })),
   };
 
-  return <Pie data={pieData} options={options} />;
+  return (
+    <Pie
+      data={pieData}
+      options={
+        options ? Object.assign(defaultOptions, options) : defaultOptions
+      }
+    />
+  );
 }

--- a/packages/client/src/dashboard/presentation/components/Common/EditToolBar.tsx
+++ b/packages/client/src/dashboard/presentation/components/Common/EditToolBar.tsx
@@ -19,6 +19,7 @@ interface EditToolBarProps {
 const EditToolBarArea = styled.div`
   display: flex;
   width: 100%;
+  height: 2rem;
   justify-content: space-between;
   border: 1px solid blue;
 `;

--- a/packages/client/src/dashboard/presentation/components/Sticker/StickerContentFactory.tsx
+++ b/packages/client/src/dashboard/presentation/components/Sticker/StickerContentFactory.tsx
@@ -5,27 +5,68 @@ import {
 } from './StickerContent.type';
 import LineChart from '../Charts/LineChart';
 import BarChart from '../Charts/BarChart';
-
+import styled from '@emotion/styled';
+import useMode from '../../../application/services/useMode';
 export interface StickerContentFactoryProps {
   type: StickerContentType;
   contentProps: StickerContentPropType;
 }
 
+const StickerContentWrapper = styled.div`
+  position: relative;
+  margin-left: auto;
+  margin-right: auto;
+  align-items: center;
+  height: calc(100% - 3rem);
+  width: calc(100% - 1rem);
+  top: 1rem;
+  &.edit {
+    top: 0rem;
+  }
+`;
+
 function StickerContentFactory(props: StickerContentFactoryProps) {
   const { type, contentProps } = props;
+  const { getControlMode } = useMode();
+  const mode = getControlMode();
+
   switch (type) {
     case 'pieChart':
-      return <PieChart {...contentProps} />;
+      return (
+        <StickerContentWrapper className={mode}>
+          <PieChart {...contentProps} />
+        </StickerContentWrapper>
+      );
     case 'lineChart':
-      return <LineChart {...contentProps} />;
+      return (
+        <StickerContentWrapper className={mode}>
+          <LineChart {...contentProps} />
+        </StickerContentWrapper>
+      );
     case 'barChart':
-      return <BarChart {...contentProps} />;
+      return (
+        <StickerContentWrapper className={mode}>
+          <BarChart {...contentProps} />
+        </StickerContentWrapper>
+      );
     case 'text':
-      return <div>개발 중</div>;
+      return (
+        <StickerContentWrapper className={mode}>
+          <div>개발 중</div>
+        </StickerContentWrapper>
+      );
     case 'table':
-      return <div>개발 중</div>;
+      return (
+        <StickerContentWrapper className={mode}>
+          <div>개발 중</div>
+        </StickerContentWrapper>
+      );
     default:
-      return <div>개발 중</div>;
+      return (
+        <StickerContentWrapper className={mode}>
+          <div>개발 중</div>
+        </StickerContentWrapper>
+      );
   }
 }
 


### PR DESCRIPTION
Sticker 내 Component가 높이에 대해 크기 조절이 되지 않는 문제 해결

#313

### 작업 동기 (Motivation)

### 변경 사항 요약 (Key changes)
- Chart가 높이에 대해서도 크기가 조절되도록 변경
  - Chart에 default options 적용
  - Sticker 내 Component를 래핑하여 사이즈 조절

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

