### PR TITLE
fix(client): save layout change when window resize event occur

### DIFF
--- a/packages/client/src/dashboard/presentation/components/Board/Board.tsx
+++ b/packages/client/src/dashboard/presentation/components/Board/Board.tsx
@@ -76,7 +76,7 @@ export default function Board() {
       <ReactGridLayout
         onDragStart={(a, b, c, d, e) => e.stopPropagation()}
         layouts={{ lg: boardData.sectionLayouts || [] }}
-        breakpoints={{ lg: 600, md: 498, sm: 384, xs: 240, xxs: 0 }}
+        breakpoints={{ lg: 600 }}
         cols={{ lg: 8, md: 5, sm: 4, xs: 2, xxs: 1 }}
         onLayoutChange={handleSectionLayoutChange}
         className="layout"


### PR DESCRIPTION
### 작업 동기 (Motivation)

### 변경 사항 요약 (Key changes)
🐛 버그 픽스인 경우 :
- 윈도우 리사이즈로 변경된 레이아웃이 저장이 되어 다시 화면이 커졌을때 변경되지 않았던 문제
- 변경되는 breakpoints 지점들을 제거 해서 해결했습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

