### PR TITLE
feat(User): feat: set user data

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,6 +12,7 @@
     "@reduxjs/toolkit": "^1.8.3",
     "axios": "^0.27.2",
     "chart.js": "^3.8.0",
+    "common": "*",
     "react": "^18.2.0",
     "react-chartjs-2": "^4.2.0",
     "react-dom": "^18.2.0",
@@ -23,7 +24,7 @@
     "uuid": "^8.3.2",
     "web-vitals": "^2.1.4",
     "zustand": "^4.0.0-rc.1",
-    "common": "*"
+    "zustand-persist": "^0.4.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/client/src/dashboard/application/services/useUser.tsx
+++ b/packages/client/src/dashboard/application/services/useUser.tsx
@@ -8,15 +8,21 @@ import userStore from '../../infrastructure/store/user.store';
 const userService = new UserService(userRepository);
 
 function useUser() {
-  const [user, setUser] = useState(userStore.getUser());
+  const [userInfo, setUserInfo] = useState(userStore.getUser());
 
-  console.log('stateStickers', user);
+  userStore.subscribeToUser((newUserData: UserType | null) => {
+    setUserInfo(newUserData);
+  });
 
   const getUser = () => {
     return userService.getUser();
   };
 
-  return { user, getUser };
+  const setUser = (user: UserType) => {
+    return userService.setUser(user);
+  };
+
+  return { userInfo, getUser, setUser };
 }
 
 export default useUser;

--- a/packages/client/src/dashboard/domain/user/user.repository.interface.ts
+++ b/packages/client/src/dashboard/domain/user/user.repository.interface.ts
@@ -1,7 +1,7 @@
 import UserType from './user.type';
 
 interface UserRepositoryInterface {
-  getUser(): Promise<UserType | null>;
+  getUser(): UserType | null;
   setUser(user: UserType): Promise<void>;
 }
 

--- a/packages/client/src/dashboard/domain/user/user.service.ts
+++ b/packages/client/src/dashboard/domain/user/user.service.ts
@@ -4,8 +4,12 @@ import UserType from './user.type';
 class UserService {
   constructor(protected userRepository: UserRepositoryInterface) {}
 
-  public async getUser(): Promise<UserType | null> {
+  public getUser(): UserType | null {
     return this.userRepository.getUser();
+  }
+
+  public setUser(user: UserType): Promise<void> {
+    return this.userRepository.setUser(user);
   }
 }
 

--- a/packages/client/src/dashboard/infrastructure/http/axios/axios.custom.ts
+++ b/packages/client/src/dashboard/infrastructure/http/axios/axios.custom.ts
@@ -6,10 +6,8 @@ const getUserInfoURL = '/auth/userInfo';
 export const axiosGetUserInfo = async () => {
   try {
     const response = await axios.instance.get(getUserInfoURL);
-    console.log(response);
     return response;
   } catch (error) {
-    console.log(error);
-    return error;
+    throw error;
   }
 };

--- a/packages/client/src/dashboard/infrastructure/store/zustand/dashboard.store.zustand.ts
+++ b/packages/client/src/dashboard/infrastructure/store/zustand/dashboard.store.zustand.ts
@@ -1,6 +1,6 @@
 import StickerDataType from '../../../domain/stickerDatas/stickerData.type';
 import create from 'zustand';
-import { devtools } from 'zustand/middleware';
+import { devtools, persist } from 'zustand/middleware';
 import ControlModeType from '../../../domain/controlMode/controlMode.type';
 import PresetType from '../../../domain/preset/preset.type';
 import UserType from '../../../domain/user/user.type';
@@ -19,17 +19,19 @@ export interface DashBoardState {
   stickerDatas: StickerDataType[];
 }
 
-const store = create<DashBoardState, [['zustand/devtools', DashBoardState]]>(
-  devtools((set) => ({
-    user: null,
-    preset: null,
-    presetList: { presetInfos: [] },
-    controlMode: 'view',
-    filtersModal: false,
-    boardData: { sectionIds: [], sectionLayouts: [] },
-    sectionDatas: [],
-    stickerDatas: [],
-  })),
+const store = create<DashBoardState>()(
+  devtools(
+    persist((set) => ({
+      user: null,
+      preset: null,
+      presetList: { presetInfos: [] },
+      controlMode: 'view',
+      filtersModal: false,
+      boardData: { sectionIds: [], sectionLayouts: [] },
+      sectionDatas: [],
+      stickerDatas: [],
+    })),
+  ),
 );
 
 export default store;

--- a/packages/client/src/dashboard/infrastructure/user.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/user.repository.ts
@@ -3,7 +3,7 @@ import UserType from '../domain/user/user.type';
 import userStore from './store/user.store';
 
 class UserRepository implements UserRepositoryInterface {
-  public async getUser(): Promise<UserType | null> {
+  public getUser(): UserType | null {
     return userStore.getUser();
   }
 

--- a/packages/client/src/dashboard/presentation/components/Login/Login.tsx
+++ b/packages/client/src/dashboard/presentation/components/Login/Login.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import useUser from '../../../application/services/useUser';
 
 const LoginPage = styled.div`
   display: flex;
@@ -19,6 +21,13 @@ const LoginButton = styled.button`
 // TODO: hybae
 // 이미 로그인이 되어있는 경우, dashboard 페이지로 라우팅
 const Login = () => {
+  const { userInfo } = useUser();
+  const navigate = useNavigate();
+
+  if (userInfo !== null) {
+    navigate(`/dashboard`);
+  }
+
   function handleClick() {
     window.location.href = 'http://dashboard42.com:3000/auth/42';
   }

--- a/packages/client/src/dashboard/presentation/pages/DashBoardPage.tsx
+++ b/packages/client/src/dashboard/presentation/pages/DashBoardPage.tsx
@@ -26,7 +26,6 @@ function DashBoardPage() {
       .then((response: any) => response.data)
       .then((data) => setUser(data))
       .catch((error) => {
-        console.log(`axios error : ${error}`);
         navigate(`/`);
       });
   }

--- a/packages/client/src/dashboard/presentation/pages/DashBoardPage.tsx
+++ b/packages/client/src/dashboard/presentation/pages/DashBoardPage.tsx
@@ -1,25 +1,36 @@
 import { Box, CssBaseline, Typography } from '@mui/material';
-import createQuery, {
-  createQueryForTable,
-} from '../../infrastructure/http/graphql/createQuery';
+import { createQueryForTable } from '../../infrastructure/http/graphql/createQuery';
 import AppBar from '../components/AppBar/AppBar';
 import ProfileMenu from '../components/AppBar/ProfileMenu/ProfileMenu';
 import Board from '../components/Board/Board';
-import Section from '../components/Board/Section';
-import BarChart from '../components/Charts/BarChart';
-import LineChart from '../components/Charts/LineChart';
-import PieChart from '../components/Charts/PieChart';
 import Logo from '../components/Logo/logo';
 import MainArea from '../components/MainArea/MainArea';
 import ModeDial from '../components/ModeDial/ModeDial';
 import SideBar from '../components/SideBar/SideBar';
 import { TableStickerContent } from '../components/Table/Table';
+import * as axios from '../../infrastructure/http/axios/axios.custom';
+import useUser from '../../application/services/useUser';
+import { useNavigate } from 'react-router';
 
 // TODO: hybae
 // userData가 null일 때 처리 추가
 // userInfo API를 통해 데이터 받아올 경우, userData set
 // 그 외의 경우, 로그인 페이지로 라우팅
 function DashBoardPage() {
+  const { userInfo, setUser } = useUser();
+  const navigate = useNavigate();
+
+  if (userInfo === null) {
+    axios
+      .axiosGetUserInfo()
+      .then((response: any) => response.data)
+      .then((data) => setUser(data))
+      .catch((error) => {
+        console.log(`axios error : ${error}`);
+        navigate(`/`);
+      });
+  }
+
   const appBarTitle = (
     <Typography
       variant="h6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18514,6 +18514,11 @@ zen-observable@0.8.15:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
+zustand-persist@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/zustand-persist/-/zustand-persist-0.4.0.tgz#55f32c3cd98ea91b89f07ae249d20e471f0a5ba3"
+  integrity sha512-u6bBIc4yZRpSKBKuTNhoqvoIb09gGHk2NkiPg4K7MPIWTYZg70PlpBn48QEDnKZwfNurnf58TaW5BuMGIMf5hw==
+
 zustand@^4.0.0-rc.1:
   version "4.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.0.0-rc.1.tgz#ec30a3afc03728adec7e1bd7bcc3592176372201"


### PR DESCRIPTION
user data 조회 및 저장

#301

### 작업 동기 (Motivation)
- 유저의 로그인 여부에 따른 동작

### 변경 사항 요약 (Key changes)
- 유저가 로그인 시, API를 통해 유저의 정보 추출 및 저장
- zustand에 persist 미들웨어 적용
- 로그인하지 않은 유저가 dashboard에 접근 시, 로그인 페이지로 라우팅

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항
- /dashboard path에서 로그인이 되어 있지 않은 경우, / path로 navigate 처리는 잘 되지만,
  / path에서 로그인이 되어 있는 경우, /dashboard path로 navigate가 되지 않는 현상이 있습니다.
  zustand의 persist 미들웨어를 통해 스토어 내에 유저데이터가 저장되어 있어 로그인이 되어 있는 경우의 조건문에 들어가는 건 확인했습니다.
  해당 이슈 추가 발행 예정입니다.