### PR TITLE
Feat/client/288

### DIFF
--- a/packages/client/src/dashboard/application/services/useDataset.tsx
+++ b/packages/client/src/dashboard/application/services/useDataset.tsx
@@ -1,21 +1,8 @@
 import { DocumentNode, useQuery } from '@apollo/client';
-import {
-  ColumnType,
-  EntityNameType,
-  GivenValueType,
-  OperatorType,
-} from '../../presentation/components/Sticker/Filter.type';
-
-export interface QueryFilterType {
-  entityName: EntityNameType | string;
-  column: ColumnType;
-  operator: OperatorType;
-  givenValue: GivenValueType;
-  latest: boolean;
-}
+import { FilterConfigType } from '../../presentation/components/Sticker/Filter.type';
 
 export interface QueryVariablesType {
-  [filterName: string]: QueryFilterType;
+  [filterName: string]: FilterConfigType;
 }
 
 export interface QueryDataType {

--- a/packages/client/src/dashboard/application/utils/tableQueryParse.js
+++ b/packages/client/src/dashboard/application/utils/tableQueryParse.js
@@ -1,0 +1,19 @@
+const destructObjectToArray = (prev, element) => {
+  const { __typename, ...row } = element;
+  const toArr = Object.values(row);
+  const newarr = [];
+  toArr.forEach((item) => {
+    if (Array.isArray(item)) {
+      console.log('ArrayItem', item);
+      const { __typename, ...cells } = item[0];
+      newarr.push(...Object.values(cells));
+    } else {
+      newarr.push(item);
+    }
+  });
+  return [...prev, newarr];
+};
+
+export const getRowsFromGqlResponse = (responseData) => {
+  return Object.values(responseData)[0].reduce(destructObjectToArray, []);
+};

--- a/packages/client/src/dashboard/infrastructure/http/graphql/createQuery.ts
+++ b/packages/client/src/dashboard/infrastructure/http/graphql/createQuery.ts
@@ -12,7 +12,6 @@ function returnFilterVariables(filterNames: string[]): string[] {
   );
   return arrayOfFilterName;
 }
-
 /**
  * @param filterSet
  * @returns
@@ -46,6 +45,30 @@ function returnRequest(labels: string[]) {
   };
 }
 
+function returnVariables(
+  filterNames: string[],
+  startDate?: Date,
+  endDate?: Date,
+  skip?: number,
+  take?: number,
+) {
+  const filterNamesLiteral = `filters: [${returnFilters(filterNames)}]`;
+  const startDateLiteral = startDate ? `startDate: ${startDate}` : '';
+  const endDateLiteral = endDate ? `endDate: ${endDate}` : '';
+  const skipLiteral = skip ? `skip: ${skip}` : '';
+  const takeLiteral = take ? `take: ${take}` : '';
+
+  const Variables = [
+    filterNamesLiteral,
+    startDateLiteral,
+    endDateLiteral,
+    skipLiteral,
+    takeLiteral,
+  ].join('\n');
+
+  return Variables;
+}
+
 /**
  * @param filterNames
  * @param labels
@@ -69,5 +92,32 @@ export default function createQuery(
   ) {
     ${filterSetsPerData.map(returnRequest(labels)).join('\n')}
   }`;
+  return gql(query);
+}
+
+export function createQueryForTable(
+  filterNames: string[],
+  fields: (string | object)[],
+  startDate?: Date,
+  endDate?: Date,
+  skip?: number,
+  take?: number,
+) {
+  const variables = returnVariables(
+    filterNames,
+    startDate,
+    endDate,
+    skip,
+    take,
+  );
+  const query = `query GetTableDatas(
+    ${returnFilterVariables(filterNames).join('\n')}
+    ) {
+       getPeopleByFilter(${variables}
+       ) {
+        ${fields.join(',\n')}
+       }
+    }
+  `;
   return gql(query);
 }

--- a/packages/client/src/dashboard/presentation/components/Modal/Dataset.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/Dataset.tsx
@@ -3,14 +3,14 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import Typography from '@mui/material/Typography';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { QueryFilterType } from '../../../application/services/useDataset';
 import QueryFilterAttribute from './QueryFilterAttribute';
 import SelectedFilter from './SelectedFilter';
+import { FilterConfigType } from '../Sticker/Filter.type';
 
 export interface DatasetProps {
   id: number;
-  dataSet: QueryFilterType[];
-  setDataSets: React.Dispatch<React.SetStateAction<QueryFilterType[][]>>;
+  dataSet: FilterConfigType[];
+  setDataSets: React.Dispatch<React.SetStateAction<FilterConfigType[][]>>;
   focus: number;
   onChange: () => void;
 }
@@ -28,7 +28,7 @@ export default function Dataset({
     });
   }
 
-  const saveSelectedFilter = (queryFilter: QueryFilterType) => {
+  const saveSelectedFilter = (queryFilter: FilterConfigType) => {
     setDataSets((prev) => {
       const newFilters = [...prev];
       newFilters[id].push(queryFilter);

--- a/packages/client/src/dashboard/presentation/components/Modal/InputDatasets.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/InputDatasets.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import Dataset from './Dataset';
 import { Button } from '@mui/material';
 import styled from '@emotion/styled';
-import { QueryFilterType } from '../../../application/services/useDataset';
+import { FilterConfigType } from '../Sticker/Filter.type';
 
 interface InputDataSetType {
-  dataSets: QueryFilterType[][];
-  setDataSets: React.Dispatch<React.SetStateAction<QueryFilterType[][]>>;
+  dataSets: FilterConfigType[][];
+  setDataSets: React.Dispatch<React.SetStateAction<FilterConfigType[][]>>;
   focus: number;
   onChange: (i: number) => () => void;
 }

--- a/packages/client/src/dashboard/presentation/components/Modal/InputLabels.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/InputLabels.tsx
@@ -2,7 +2,6 @@ import AddCircleOutlineOutlinedIcon from '@mui/icons-material/AddCircleOutlineOu
 import LabelFilter from './LabelFilter';
 import styled from '@emotion/styled';
 import { useState } from 'react';
-import { QueryFilterType } from '../../../application/services/useDataset';
 import { FilterConfigType } from '../Sticker/Filter.type';
 import SelectedFilter from './SelectedFilter';
 
@@ -14,11 +13,10 @@ const Button = styled(AddCircleOutlineOutlinedIcon)`
 
 export interface SelectedLabelFilters extends FilterConfigType {
   label?: string;
-  latest?: boolean;
 }
 
 interface FiltersProps {
-  setLabelAndFilter: (label: string, filter: QueryFilterType) => void;
+  setLabelAndFilter: (label: string, filter: FilterConfigType) => void;
   selectedLabels: SelectedLabelFilters[];
   setSelectedLabels: React.Dispatch<
     React.SetStateAction<SelectedLabelFilters[]>

--- a/packages/client/src/dashboard/presentation/components/Modal/LabelFilter.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/LabelFilter.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import { SelectedLabelFilters } from './InputLabels';
 import LabelAttribute from './filterAttributes/LabelAttribute';
-import { QueryFilterType } from '../../../application/services/useDataset';
 import QueryFilterAttribute from './QueryFilterAttribute';
+import { FilterConfigType } from '../Sticker/Filter.type';
 
 const Section = styled.div`
   margin-top: 1rem;
@@ -13,7 +13,7 @@ const Section = styled.div`
 `;
 
 interface LabelFilterProps {
-  setLabelAndFilter: (label: string, filter: QueryFilterType) => void;
+  setLabelAndFilter: (label: string, filter: FilterConfigType) => void;
   addFilter: (newFilter: SelectedLabelFilters) => void;
 }
 
@@ -21,7 +21,7 @@ function LabelFilter(props: LabelFilterProps) {
   const { setLabelAndFilter, addFilter } = props;
   const [label, setLabel] = React.useState<string>('');
 
-  const saveSelectedFilter = (queryFilter: QueryFilterType) => {
+  const saveSelectedFilter = (queryFilter: FilterConfigType) => {
     setLabelAndFilter(label, queryFilter);
     addFilter({ label, ...queryFilter });
   };

--- a/packages/client/src/dashboard/presentation/components/Modal/Modal.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/Modal.tsx
@@ -1,10 +1,10 @@
 import { Box, Modal } from '@mui/material';
 import { useState } from 'react';
-import { QueryFilterType } from '../../../application/services/useDataset';
 import { StickerContentType } from '../Sticker/StickerContent.type';
 import StickerDataType from '../../../domain/stickerDatas/stickerData.type';
 import makeStickerData from './makeStickerData';
 import StickerStepper from './StickerStepper';
+import { FilterConfigType } from '../Sticker/Filter.type';
 
 interface ModalProps {
   sectionId: string;
@@ -33,8 +33,8 @@ const ModalFrame = (props: ModalProps) => {
 
   const [type, setType] = useState<StickerContentType>('lineChart');
   const [labels, setLabels] = useState<string[]>([]);
-  const [filters, setFilters] = useState<QueryFilterType[]>([]);
-  const [dataSets, setDataSets] = useState<QueryFilterType[][]>([[]]);
+  const [filters, setFilters] = useState<FilterConfigType[]>([]);
+  const [dataSets, setDataSets] = useState<FilterConfigType[][]>([[]]);
 
   function AddStickerDataset() {
     const newStickerData = makeStickerData({

--- a/packages/client/src/dashboard/presentation/components/Modal/QueryFilterAttribute.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/QueryFilterAttribute.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import { QueryFilterType } from '../../../application/services/useDataset';
 import { useLazyQuery } from '@apollo/client';
 import createValueQuery from '../../../infrastructure/http/graphql/createValueQuery';
 import {
   ColumnType,
   EntityNameType,
+  FilterConfigType,
   GivenValueType,
   OperatorType,
 } from '../Sticker/Filter.type';
@@ -25,7 +25,7 @@ const Section = styled.div`
 `;
 
 interface DatasetFilterProps {
-  saveSelectedFilter: (queryFilter: QueryFilterType) => void;
+  saveSelectedFilter: (queryFilter: FilterConfigType) => void;
 }
 
 export default function QueryFilterAttribute(props: DatasetFilterProps) {

--- a/packages/client/src/dashboard/presentation/components/Modal/StickerStepper.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/StickerStepper.tsx
@@ -8,10 +8,10 @@ import Typography from '@mui/material/Typography';
 import TypeBox from './TypeBox';
 import { SelectedLabelFilters } from './InputLabels';
 import styled from '@emotion/styled';
-import { QueryFilterType } from '../../../application/services/useDataset';
 import { StickerContentType } from '../Sticker/StickerContent.type';
 import InputLabels from './InputLabels';
 import InputDatasets from './InputDatasets';
+import { FilterConfigType } from '../Sticker/Filter.type';
 
 const steps = ['Type 정하기!', 'label 정하기!', 'dataset 정하기!'];
 
@@ -21,11 +21,11 @@ const StyledDiv = styled.div`
 `;
 
 interface ModalDatasType {
-  dataSets: QueryFilterType[][];
+  dataSets: FilterConfigType[][];
   setType: React.Dispatch<React.SetStateAction<StickerContentType>>;
   setLabels: React.Dispatch<React.SetStateAction<string[]>>;
-  setFilters: React.Dispatch<React.SetStateAction<QueryFilterType[]>>;
-  setDataSets: React.Dispatch<React.SetStateAction<QueryFilterType[][]>>;
+  setFilters: React.Dispatch<React.SetStateAction<FilterConfigType[]>>;
+  setDataSets: React.Dispatch<React.SetStateAction<FilterConfigType[][]>>;
   applyFiltersModal: () => void;
 }
 
@@ -68,9 +68,9 @@ export default function StickerStepper(props: ModalDatasType) {
     };
   };
 
-  const setLabelAndFilter = (label: string, filter: QueryFilterType) => {
+  const setLabelAndFilter = (label: string, filter: FilterConfigType) => {
     setLabels((labels: string[]) => [...labels, label]);
-    setFilters((filters: QueryFilterType[]) => [...filters, filter]);
+    setFilters((filters: FilterConfigType[]) => [...filters, filter]);
   };
 
   function PageComponent() {

--- a/packages/client/src/dashboard/presentation/components/Modal/makeStickerData.ts
+++ b/packages/client/src/dashboard/presentation/components/Modal/makeStickerData.ts
@@ -3,11 +3,11 @@ import createQuery from '../../../infrastructure/http/graphql/createQuery';
 import { v4 as uuid } from 'uuid';
 import {
   QueryDataType,
-  QueryFilterType,
   QueryVariablesType,
 } from '../../../application/services/useDataset';
 import { DocumentNode } from '@apollo/client';
 import { StickerContentType } from '../Sticker/StickerContent.type';
+import { FilterConfigType } from '../Sticker/Filter.type';
 
 function stringToUnicode(str: string): string {
   let ret = '';
@@ -17,10 +17,10 @@ function stringToUnicode(str: string): string {
   return ret;
 }
 
-function returnFilterName(filter: QueryFilterType): string {
-  return `${filter.entityName}${filter.column}${stringToUnicode(
-    filter.operator,
-  )}${stringToUnicode(filter.givenValue)}`;
+function returnFilterName(filter: FilterConfigType): string {
+  return `${filter.entityName}${filter.column}${
+    filter.operator && stringToUnicode(filter.operator)
+  }${stringToUnicode(filter.givenValue)}`;
 }
 
 function changeFirstCharOfEntity(entityName: string) {
@@ -30,11 +30,11 @@ function changeFirstCharOfEntity(entityName: string) {
 }
 
 function makeQueryFilterVariables(
-  filters: QueryFilterType[],
+  filters: FilterConfigType[],
 ): QueryVariablesType {
   const queryVariables: QueryVariablesType = {};
 
-  filters.forEach((filter: QueryFilterType) => {
+  filters.forEach((filter: FilterConfigType) => {
     const filterName = returnFilterName(filter);
     queryVariables[filterName] = {
       ...filter,
@@ -50,14 +50,14 @@ function returnFilterNames(queryVariables: QueryVariablesType): string[] {
 }
 
 function returnFilterSets(
-  arrayOfDataSet: QueryFilterType[][],
-  labelFilter: QueryFilterType[],
+  arrayOfDataSet: FilterConfigType[][],
+  labelFilter: FilterConfigType[],
 ): string[][] {
   const labelFilterNames = labelFilter.map((filter) =>
     returnFilterName(filter),
   );
   const filterSets: string[][] = [];
-  arrayOfDataSet.forEach((dataSet: QueryFilterType[]) => {
+  arrayOfDataSet.forEach((dataSet: FilterConfigType[]) => {
     const commonFilterNames = dataSet.map((filter) => returnFilterName(filter));
     labelFilterNames.forEach((labelName) => {
       const dataSet = [...commonFilterNames];
@@ -72,8 +72,8 @@ export interface MakeStickerType {
   sectionId: string;
   type: StickerContentType;
   labels: string[];
-  labelFilter: QueryFilterType[];
-  arrayOfDataSet: QueryFilterType[][];
+  labelFilter: FilterConfigType[];
+  arrayOfDataSet: FilterConfigType[][];
 }
 
 export default function makeStickerData({

--- a/packages/client/src/dashboard/presentation/components/Sticker/Filter.type.ts
+++ b/packages/client/src/dashboard/presentation/components/Sticker/Filter.type.ts
@@ -45,9 +45,10 @@ export type GivenValueType = any; // 이후 모든 필드의 데이터 타입이
 
 export interface FilterConfigType {
   entityName: EntityNameType | string;
-  column: ColumnType;
-  operator: OperatorType;
-  givenValue: GivenValueType;
+  column: ColumnType | null;
+  operator: OperatorType | null;
+  givenValue: GivenValueType | null;
+  latest: boolean;
 }
 
 export interface FilterType {

--- a/packages/client/src/dashboard/presentation/components/Table/Table.stories.tsx
+++ b/packages/client/src/dashboard/presentation/components/Table/Table.stories.tsx
@@ -1,0 +1,43 @@
+import { TableProps } from '@mui/material';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { createQueryForTable } from '../../../infrastructure/http/graphql/createQuery';
+import { TableStickerContent } from './Table';
+
+export default {
+  title: 'Table',
+  component: TableStickerContent,
+} as ComponentMeta<typeof TableStickerContent>;
+
+const Template: ComponentStory<typeof TableStickerContent> = (args) => (
+  <TableStickerContent {...args} />
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  columnGroups: [
+    { id: 'user', colSpan: 3, label: '기본 정보' },
+    { id: 'personal', colSpan: 2, label: '개인 정보' },
+  ],
+  columns: [
+    { id: 'intraNo', label: '인트라 No.' },
+    { id: 'name', label: '이름' },
+    { id: 'grade', label: '기수' },
+    { id: 'age', label: '나이' },
+    { id: 'gender', label: '성별' },
+  ],
+  queryData: {
+    query: createQueryForTable(
+      ['personalData'],
+      ['intra_no', 'name', 'grade', 'userPersonalInformation {age, gender}'],
+    ),
+    filters: {
+      personalData: {
+        entityName: 'userPersonalInformation',
+        column: null,
+        operator: null,
+        givenValue: null,
+        latest: true,
+      },
+    },
+  },
+};

--- a/packages/client/src/dashboard/presentation/pages/DashBoardPage.tsx
+++ b/packages/client/src/dashboard/presentation/pages/DashBoardPage.tsx
@@ -1,5 +1,7 @@
 import { Box, CssBaseline, Typography } from '@mui/material';
-import createQuery from '../../infrastructure/http/graphql/createQuery';
+import createQuery, {
+  createQueryForTable,
+} from '../../infrastructure/http/graphql/createQuery';
 import AppBar from '../components/AppBar/AppBar';
 import ProfileMenu from '../components/AppBar/ProfileMenu/ProfileMenu';
 import Board from '../components/Board/Board';
@@ -11,6 +13,7 @@ import Logo from '../components/Logo/logo';
 import MainArea from '../components/MainArea/MainArea';
 import ModeDial from '../components/ModeDial/ModeDial';
 import SideBar from '../components/SideBar/SideBar';
+import { TableStickerContent } from '../components/Table/Table';
 
 // TODO: hybae
 // userData가 null일 때 처리 추가
@@ -57,6 +60,35 @@ function DashBoardPage() {
     <ProfileMenu menuItems={profileMenuItems} profile={profile} />
   );
 
+  const tableProps = {
+    columnGroups: [
+      { id: 'user', colSpan: 3, label: '기본 정보' },
+      { id: 'personal', colSpan: 2, label: '개인 정보' },
+    ],
+    columns: [
+      { id: 'intraNo', label: '인트라 No.' },
+      { id: 'name', label: '이름' },
+      { id: 'grade', label: '기수' },
+      { id: 'age', label: '나이' },
+      { id: 'gender', label: '성별' },
+    ],
+    queryData: {
+      query: createQueryForTable(
+        ['personalData'],
+        ['intra_no', 'name', 'grade', 'userPersonalInformation {age, gender}'],
+      ),
+      filters: {
+        personalData: {
+          entityName: 'userPersonalInformation',
+          column: null,
+          operator: null,
+          givenValue: null,
+          latest: true,
+        },
+      },
+    },
+  };
+
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
@@ -67,6 +99,7 @@ function DashBoardPage() {
       </AppBar>
       <SideBar />
       <MainArea>
+        <TableStickerContent {...tableProps} />
         <Board />
       </MainArea>
       <ModeDial />


### PR DESCRIPTION
### 작업 동기 (Motivation)

-Table 컴포넌트가 props를 받아서 쿼리를 요청하고 받아온 데이터로 테이블을 그릴 수 있게된다.

### 변경 사항 요약 (Key changes)
- table을 그리기 위해 필요한 조건들이 차트와 달라서 createQueryForTable 이라는 쿼리 빌더 유틸리티를 추가했습니다.
- props이 정상적으로 들어왔을 때는, 테이블이 잘 그려집니다. 

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부
![image](https://user-images.githubusercontent.com/35288028/181513880-62671da4-d39e-4e70-89e2-f652f0339fa7.png)

### 리뷰어들에게 요청사항

