### PR TITLE
fix(server): feated: add API for Edit process

### DIFF
--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -50,11 +50,12 @@ type Mutation {
 
 type Query {
   extractDataIntoSpreadsheet: String!
-  getDomainOfColumnFilter(filters: [Filter!]!, skip: Int, take: Int): [JoinedTable!]!
+  getDataToModifyFromDB(sheetName: String!): String!
+  getDomainOfColumnFilter(filters: [Filter!]!, skip: Int, take: Int, timeReference: DateTime): [JoinedTable!]!
   getLatestData: String!
-  getNumOfPeopleByFilter(filters: [Filter!]!, skip: Int, take: Int): Int!
-  getPeopleByFilter(filters: [Filter!]!, skip: Int, take: Int): [JoinedTable!]!
-  getPeopleByFilterForAdmin(filters: [Filter!]!, skip: Int, take: Int): [JoinedTable!]!
+  getNumOfPeopleByFilter(filters: [Filter!]!, skip: Int, take: Int, timeReference: DateTime): Int!
+  getPeopleByFilter(filters: [Filter!]!, skip: Int, take: Int, timeReference: DateTime): [JoinedTable!]!
+  getPeopleByFilterForAdmin(filters: [Filter!]!, skip: Int, take: Int, timeReference: DateTime): [JoinedTable!]!
   getUser(column: String, duplicated: String!): [User!]!
   getUserAccessCardInformation(column: String, duplicated: String!): [UserAccessCardInformation!]!
   getUserBlackhole(column: String, duplicated: String!): [UserBlackhole!]!
@@ -72,6 +73,7 @@ type Query {
   getUserOtherEmploymentStatus(column: String, duplicated: String!): [UserOtherEmploymentStatus!]!
   getUserOtherInformation(column: String, duplicated: String!): [UserOtherInformation!]!
   getUserPersonalInformation(column: String, duplicated: String!): [UserPersonalInformation!]!
+  saveModifiedDataFromSheet(sheetName: String!): String!
   sendRequestToSpreadWithGoogleAPI: String!
   tempFunction: [JoinedTable!]!
   updateData: String!

--- a/packages/server/src/updater/updater.resolver.ts
+++ b/packages/server/src/updater/updater.resolver.ts
@@ -3,6 +3,7 @@ import { UpdaterService } from './updater.service';
 import { Updater } from './entities/updater.entity';
 import { CreateUpdaterInput } from './dto/create-updater.input';
 import { UpdateUpdaterInput } from './dto/update-updater.input';
+import { UpdateDB } from 'src/user_information/argstype/updateSheet.argstype';
 
 @Resolver(() => Updater)
 export class UpdaterResolver {
@@ -21,6 +22,16 @@ export class UpdaterResolver {
   @Query(() => String)
   extractDataIntoSpreadsheet() {
     return this.updaterService.extractDataIntoSpreadsheet();
+  }
+
+  @Query(() => String)
+  getDataToModifyFromDB(@Args() updateDB: UpdateDB) {
+    return this.updaterService.getDataToModifyFromDB(updateDB);
+  }
+
+  @Query(() => String)
+  saveModifiedDataFromSheet(@Args() updateDB: UpdateDB) {
+    return this.updaterService.saveModifiedDataFromSheet(updateDB);
   }
 
   @Query(() => String)

--- a/packages/server/src/updater/updater.service.ts
+++ b/packages/server/src/updater/updater.service.ts
@@ -37,6 +37,7 @@ import {
   UserEducationFundState,
 } from 'src/user_payment/entity/user_payment.entity';
 import { MAIN_SHEET, SPREAD_END_POINT } from 'src/config/key';
+import { UpdateDB } from 'src/user_information/argstype/updateSheet.argstype';
 
 interface RepoDict {
   [repositoryName: string]:
@@ -287,15 +288,42 @@ export class UpdaterService {
   }
 
   async extractDataIntoSpreadsheet() {
-    return await this.spreadService.createSpreadsheet(
+    //시트를 삭제하는 명령
+    const deletePage = [
+      {
+        deleteSheet: {
+          sheetId: 'user',
+        },
+      },
+    ];
+    const googleSheet = await this.spreadService.getGoogleSheetAPI();
+    await this.spreadService.controlSheet(
       SPREAD_END_POINT,
-      'googleapi/newpage',
+      googleSheet,
+      deletePage,
     );
+    return await '';
+  }
+
+  async getDataToModifyFromDB(updateDB: UpdateDB) {
+    await this.spreadService.getDataToModifyFromDB(
+      SPREAD_END_POINT,
+      updateDB.sheetName,
+    );
+    return 'done';
+  }
+
+  async saveModifiedDataFromSheet(updateDB: UpdateDB) {
+    await this.spreadService.saveModifiedDataFromSheet(
+      SPREAD_END_POINT,
+      updateDB.sheetName,
+    );
+    return 'done';
   }
 
   async findTargetByKey(repo, repoKey, newOneData, targetObj) {
     const emptyObj = {};
-    console.log(repoKey, '\n', 'new:', newOneData, '!!');
+    //console.log(repoKey, '\n', 'new:', newOneData, '!!');
     try {
       //스프레드 데이터가 db 데이터에 있는지 확인.
       for (const target of targetObj) {

--- a/packages/server/src/user_information/argstype/updateSheet.argstype.ts
+++ b/packages/server/src/user_information/argstype/updateSheet.argstype.ts
@@ -1,12 +1,10 @@
 import { ArgsType, Field, Int } from '@nestjs/graphql';
 
 @ArgsType()
-export class CheckDuplication {
+export class UpdateDB {
   // @Field((type) => GraphQLJSON, { nullable: true })
   // filters: JSON;
 
   @Field() //에러발생 -> Filter 선언부쪽에 @InputType()붙여주니까 해결됨
-  duplicated: string;
-  @Field({ nullable: true })
-  column?: string;
+  sheetName: string;
 }

--- a/packages/server/src/user_information/utils/getDomain.utils.ts
+++ b/packages/server/src/user_information/utils/getDomain.utils.ts
@@ -59,6 +59,8 @@ export async function getDomain(
       .orderBy(`${repoName}.${checkDuplication.column}`)
       .getMany();
   } else {
-    return await dataSource.getRepository(entitys[repoName]).find({});
+    const res = await dataSource.getRepository(entitys[repoName]).find({});
+    console.log(res);
+    return res;
   }
 }


### PR DESCRIPTION

feat #307

### 작업 동기 (Motivation)
- pgadmin을 대신해서 수정 작업을 할 수있는 api를  따로 구성하였습니다.

### 변경 사항 요약 (Key changes)
- getDataToModifyFromDB을 사용하여 특정 테이블의 Data를 가져온 뒤, table의 이름으로 sheet를 생성
    - sheet에 있는 데이터를 직접 수정 가능
    - 불러온 sheet의 컬럼과 키에 색상 추가예정
- saveModifiedDataFromSheet을 사용하여 가져온 데이터를 DB에 다시 저장 후 sheet 삭제
    - 사용자가 수정할 수 있는 범위를 추가예정
 

예시코드 

```query {
  getDataToModifyFromDB(sheetName: "userComputationFund")
}

query {
  saveModifiedDataFromSheet(sheetName: "user")
}
```

### 체크리스트
- [x] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).


### 스크린샷 첨부
<img width="542" alt="image" src="https://user-images.githubusercontent.com/55140432/181687880-c9e3294c-d642-4aef-9bb0-b96fc03802de.png">
