### PR TITLE
feat(client/board): presetlist에 아이템 유무에 따른 보드 렌더링 처리

### DIFF
--- a/packages/client/src/dashboard/application/services/usePreset.tsx
+++ b/packages/client/src/dashboard/application/services/usePreset.tsx
@@ -14,11 +14,14 @@ import SectionDataType from '../../domain/sectionDatas/sectionData.type';
 import StickerDataType from '../../domain/stickerDatas/stickerData.type';
 import presetListRepository from '../../infrastructure/presetList.repository';
 import PresetListService from '../../domain/presetList/presetList.service';
+import useMode from '../../application/services/useMode';
 
 const presetService = new PresetService(presetRepository);
 const presetListService = new PresetListService(presetListRepository);
 
 function usePreset() {
+  const { setControlMode } = useMode();
+
   const [preset, setPreset] = useState<PresetType | null>(
     presetStore.getPreset(),
   );
@@ -38,8 +41,12 @@ function usePreset() {
   useEffect(() => {
     const fetchPresetList = async () => {
       const presetList = await presetListService.getPresetList();
-      if (presetList) {
+      if (presetList.presetInfos.length !== 0) {
         presetListStore.setPresetList(presetList);
+        changePreset(presetList.presetInfos[0].id);
+      } else {
+        createPreset();
+        setControlMode('edit');
       }
     };
     fetchPresetList();


### PR DESCRIPTION
### 작업 동기 (Motivation)
- 사이드바에서 presetlist에서 item을 선택해야지만 보고싶은 board가 렌더링되는 불편함을 해소하기 위함.
- 프리셋이 없을 때 프리셋 추가가 용이하도록 edit 모드로 렌더링하기 위함.

### 변경 사항 요약 (Key changes)
- 적용된 변경 사항 요약
- presetlist에 아이템이 있다면 첫번째 아이템 선택해서 렌더링하고, 없다면 edit모드로 default preset 활성화

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

