### PR TITLE
preset마다 제목을 변경할 수 있는 컴포넌트 만들기

### DIFF
--- a/packages/client/src/dashboard/application/services/usePreset.tsx
+++ b/packages/client/src/dashboard/application/services/usePreset.tsx
@@ -95,7 +95,28 @@ function usePreset() {
     });
   };
 
-  return { preset, presetList, createPreset, changePreset };
+  const changePresetLabel = async (id: string, label: string) => {
+    const presetData = await presetService.getPreset(id);
+    if (presetData && presetList) {
+      const newPresetInfoList = presetList.presetInfos.filter(
+        (presetInfo) => presetInfo.id !== id,
+      );
+      const newPresetInfo = {
+        id: id,
+        label: label,
+        description: '프리셋 설명',
+      };
+      presetStore.setPreset({
+        id: id,
+        data: presetData.data,
+        info: newPresetInfo,
+      });
+      presetListStore.setPresetList({
+        presetInfos: [newPresetInfo, ...newPresetInfoList],
+      });
+    }
+  };
+  return { preset, presetList, createPreset, changePreset, changePresetLabel };
 }
 
 export default usePreset;

--- a/packages/client/src/dashboard/application/services/usePreset.tsx
+++ b/packages/client/src/dashboard/application/services/usePreset.tsx
@@ -46,7 +46,6 @@ function usePreset() {
         changePreset(presetList.presetInfos[0].id);
       } else {
         createPreset();
-        setControlMode('edit');
       }
     };
     fetchPresetList();
@@ -93,6 +92,7 @@ function usePreset() {
     presetListStore.setPresetList({
       presetInfos: [...presetList.presetInfos, newPresetInfo],
     });
+    setControlMode('edit');
   };
 
   const changePresetLabel = async (id: string, label: string) => {

--- a/packages/client/src/dashboard/infrastructure/presetList.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/presetList.repository.ts
@@ -15,7 +15,6 @@ class PresetListRepository implements PresetListRepositoryInterface {
         presetInfos.push(preset.info);
       }
     }
-
     return { presetInfos };
   }
 

--- a/packages/client/src/dashboard/presentation/components/SideBar/PresetListItem.tsx
+++ b/packages/client/src/dashboard/presentation/components/SideBar/PresetListItem.tsx
@@ -1,0 +1,61 @@
+import { SvgIconComponent } from '@mui/icons-material';
+import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import useMode from '../../../application/services/useMode';
+import { useState } from 'react';
+import TextField from '@mui/material/TextField';
+
+export interface PresetListItemProps {
+  icon: SvgIconComponent; // mui/icons-material 에 있는 아이콘 타입
+  label: string;
+  description?: string;
+  selected?: boolean;
+  onClick?: () => void;
+  changePresetLabel: (id: string, label: string) => void;
+  id: string;
+}
+
+function PresetListItem(props: PresetListItemProps) {
+  const { icon, label, onClick, selected, changePresetLabel, id } = props;
+  const [edit, setEdit] = useState(false);
+  const [presetLabel, setPresetLabel] = useState(label);
+  const { getControlMode } = useMode();
+  const IconType = icon;
+
+  function myOnClickHandler(e: any) {
+    e.stopPropagation();
+    changePresetLabel(id, presetLabel);
+    console.log('edit');
+    setEdit(!edit);
+  }
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPresetLabel(event.target.value);
+  };
+  return (
+    <ListItemButton
+      sx={{ pl: 4 }}
+      onClick={onClick || undefined}
+      selected={selected || false}
+    >
+      <ListItemIcon>
+        <IconType />
+      </ListItemIcon>
+      {selected && getControlMode() === 'edit' && !edit ? (
+        <>
+          <TextField
+            id="outlined-name"
+            label="Name"
+            value={presetLabel}
+            onChange={handleChange}
+          />
+          <EditIcon color="disabled" onClick={myOnClickHandler} />
+        </>
+      ) : (
+        <ListItemText primary={presetLabel} />
+      )}
+    </ListItemButton>
+  );
+}
+
+export default PresetListItem;

--- a/packages/client/src/dashboard/presentation/components/SideBar/SideBar.tsx
+++ b/packages/client/src/dashboard/presentation/components/SideBar/SideBar.tsx
@@ -10,7 +10,8 @@ import SideBarList from './SideBarList';
 import SideBarListItem from './SideBarListItem';
 
 function SideBar() {
-  const { presetList, preset, changePreset, createPreset } = usePreset();
+  const { presetList, preset, changePreset, createPreset, changePresetLabel } =
+    usePreset();
 
   const drawerWidth = 240;
   return (
@@ -28,16 +29,21 @@ function SideBar() {
           {presetList.presetInfos.map((presetInfo) => (
             <SideBarListItem
               key={presetInfo.id}
+              id={presetInfo.id}
               icon={ShowChart}
               label={presetInfo.label}
               description={presetInfo.description}
               onClick={() => changePreset(presetInfo.id)}
               selected={presetInfo.id === preset?.id}
+              changePresetLabel={changePresetLabel}
             />
           ))}
+          {/* TODO(sonkang): label 수정이 필요없는 컴포넌트는 적용이 안되게끔 수정 */}
           <SideBarListItem
             icon={Addchart}
+            id="hi"
             label="보드 추가"
+            changePresetLabel={changePresetLabel}
             onClick={() => {
               createPreset();
             }}
@@ -45,7 +51,12 @@ function SideBar() {
         </SideBarList>
         <Divider />
         <SideBarList label="Future" icon={ExtensionSharp}>
-          <SideBarListItem icon={ShowChart} label="미래기능" />
+          <SideBarListItem
+            icon={ShowChart}
+            changePresetLabel={changePresetLabel}
+            id="hi"
+            label="미래기능"
+          />
         </SideBarList>
       </Box>
     </Drawer>

--- a/packages/client/src/dashboard/presentation/components/SideBar/SideBar.tsx
+++ b/packages/client/src/dashboard/presentation/components/SideBar/SideBar.tsx
@@ -8,6 +8,7 @@ import { Box, Divider, Drawer, Toolbar } from '@mui/material';
 import usePreset from '../../../application/services/usePreset';
 import SideBarList from './SideBarList';
 import SideBarListItem from './SideBarListItem';
+import PresetListItem from './PresetListItem';
 
 function SideBar() {
   const { presetList, preset, changePreset, createPreset, changePresetLabel } =
@@ -27,7 +28,7 @@ function SideBar() {
       <Box sx={{ overflow: 'auto' }}>
         <SideBarList label="DashBoard" icon={AssessmentSharp}>
           {presetList.presetInfos.map((presetInfo) => (
-            <SideBarListItem
+            <PresetListItem
               key={presetInfo.id}
               id={presetInfo.id}
               icon={ShowChart}
@@ -38,12 +39,9 @@ function SideBar() {
               changePresetLabel={changePresetLabel}
             />
           ))}
-          {/* TODO(sonkang): label 수정이 필요없는 컴포넌트는 적용이 안되게끔 수정 */}
           <SideBarListItem
             icon={Addchart}
-            id="hi"
             label="보드 추가"
-            changePresetLabel={changePresetLabel}
             onClick={() => {
               createPreset();
             }}
@@ -51,12 +49,7 @@ function SideBar() {
         </SideBarList>
         <Divider />
         <SideBarList label="Future" icon={ExtensionSharp}>
-          <SideBarListItem
-            icon={ShowChart}
-            changePresetLabel={changePresetLabel}
-            id="hi"
-            label="미래기능"
-          />
+          <SideBarListItem icon={ShowChart} label="미래기능" />
         </SideBarList>
       </Box>
     </Drawer>

--- a/packages/client/src/dashboard/presentation/components/SideBar/SideBarListItem.tsx
+++ b/packages/client/src/dashboard/presentation/components/SideBar/SideBarListItem.tsx
@@ -1,5 +1,8 @@
 import { SvgIconComponent } from '@mui/icons-material';
 import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import { useState } from 'react';
+import TextField from '@mui/material/TextField';
 
 export interface SideBarListItemProps {
   icon: SvgIconComponent; // mui/icons-material 에 있는 아이콘 타입
@@ -7,12 +10,26 @@ export interface SideBarListItemProps {
   description?: string;
   selected?: boolean;
   onClick?: () => void;
+  changePresetLabel: (id: string, label: string) => void;
+  id: string;
 }
 
 function SideBarListItem(props: SideBarListItemProps) {
-  const { icon, label, onClick, selected } = props;
+  const { icon, label, onClick, selected, changePresetLabel, id } = props;
+  const [edit, setEdit] = useState(false);
+  const [presetLabel, setPresetLabel] = useState('새 프리셋');
   const IconType = icon;
 
+  function myOnClickHandler(e: any) {
+    e.stopPropagation();
+    changePresetLabel(id, presetLabel);
+    console.log('edit');
+    setEdit(!edit);
+  }
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setPresetLabel(event.target.value);
+  };
   return (
     <ListItemButton
       sx={{ pl: 4 }}
@@ -22,7 +39,17 @@ function SideBarListItem(props: SideBarListItemProps) {
       <ListItemIcon>
         <IconType />
       </ListItemIcon>
-      <ListItemText primary={label} />
+      {edit ? (
+        <TextField
+          id="outlined-name"
+          label="Name"
+          value={presetLabel}
+          onChange={handleChange}
+        />
+      ) : (
+        <ListItemText primary={label} />
+      )}
+      <EditIcon color="disabled" onClick={myOnClickHandler} />
     </ListItemButton>
   );
 }

--- a/packages/client/src/dashboard/presentation/components/SideBar/SideBarListItem.tsx
+++ b/packages/client/src/dashboard/presentation/components/SideBar/SideBarListItem.tsx
@@ -1,8 +1,5 @@
 import { SvgIconComponent } from '@mui/icons-material';
 import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import { useState } from 'react';
-import TextField from '@mui/material/TextField';
 
 export interface SideBarListItemProps {
   icon: SvgIconComponent; // mui/icons-material 에 있는 아이콘 타입
@@ -10,26 +7,12 @@ export interface SideBarListItemProps {
   description?: string;
   selected?: boolean;
   onClick?: () => void;
-  changePresetLabel: (id: string, label: string) => void;
-  id: string;
 }
 
 function SideBarListItem(props: SideBarListItemProps) {
-  const { icon, label, onClick, selected, changePresetLabel, id } = props;
-  const [edit, setEdit] = useState(false);
-  const [presetLabel, setPresetLabel] = useState('새 프리셋');
+  const { icon, label, onClick, selected } = props;
   const IconType = icon;
 
-  function myOnClickHandler(e: any) {
-    e.stopPropagation();
-    changePresetLabel(id, presetLabel);
-    console.log('edit');
-    setEdit(!edit);
-  }
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setPresetLabel(event.target.value);
-  };
   return (
     <ListItemButton
       sx={{ pl: 4 }}
@@ -39,17 +22,7 @@ function SideBarListItem(props: SideBarListItemProps) {
       <ListItemIcon>
         <IconType />
       </ListItemIcon>
-      {edit ? (
-        <TextField
-          id="outlined-name"
-          label="Name"
-          value={presetLabel}
-          onChange={handleChange}
-        />
-      ) : (
-        <ListItemText primary={label} />
-      )}
-      <EditIcon color="disabled" onClick={myOnClickHandler} />
+      <ListItemText primary={label} />
     </ListItemButton>
   );
 }


### PR DESCRIPTION
### 작업 동기 (Motivation)
preset마다 제목을 변경할 수 있도록 하고 싶었습니다.

### 변경 사항 요약 (Key changes)
- 적용된 변경 사항 요약
  - preset마다 제목을 변경할 수 있도록 하였고, 새로고침 하더라도 제목이 저장될 수 있도록 하였습니다.
  - preset를 추가할 때 바로 edit 모드로 변경되게 하였습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항
제목 변경하는 방법이 살짝 복잡한데.. 더 좋은 아이디어가 있으시면 언제든지 말씀해주세요 :) !
