### PR TITLE
feat(client): 백엔드 api를 사용하여 프리셋 저장, 수정, 삭제

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             - "5432:5432"
         environment:
             POSTGRES_USER: "postgres"
-            POSTGRES_PASSWORD: "504201"
+            POSTGRES_PASSWORD: "postgres"
         stdin_open: true
         tty: true
         networks:

--- a/packages/client/src/dashboard/application/services/useBoard.tsx
+++ b/packages/client/src/dashboard/application/services/useBoard.tsx
@@ -9,6 +9,8 @@ import PresetService from '../../domain/preset/preset.service';
 import sectionDatasStore from '../../infrastructure/store/sectionDatas.store';
 import stickerDatasStore from '../../infrastructure/store/stickerDatas.store';
 import presetStore from '../../infrastructure/store/preset.store';
+import PresetListService from '../../domain/presetList/presetList.service';
+import presetListRepository from '../../infrastructure/presetList.repository';
 
 const boardDataService = new BoardDataService(boardDataRepository);
 const presetService = new PresetService(presetRepository);
@@ -19,6 +21,7 @@ function useBoard() {
   boardDataStore.subscribeToBoardData((newBoardData: BoardDataType) => {
     setBoardData(newBoardData);
   });
+
   const handleSavePreset = () => {
     const preset = presetStore.getPreset();
     if (!preset) return;
@@ -36,6 +39,11 @@ function useBoard() {
       info: preset.info,
     });
   };
+
+  const handleDeletePreset = async (id: string) => {
+    await presetService.deletePreset(id);
+  };
+
   const handleSectionAdd = (sectionId: string | undefined) => {
     if (sectionId === undefined) return;
     const newLayout = [
@@ -74,6 +82,7 @@ function useBoard() {
     handleSectionLayoutChange,
     handleSectionRemove,
     handleSavePreset,
+    handleDeletePreset,
   };
 }
 

--- a/packages/client/src/dashboard/application/services/usePreset.tsx
+++ b/packages/client/src/dashboard/application/services/usePreset.tsx
@@ -15,6 +15,8 @@ import StickerDataType from '../../domain/stickerDatas/stickerData.type';
 import presetListRepository from '../../infrastructure/presetList.repository';
 import PresetListService from '../../domain/presetList/presetList.service';
 import useMode from '../../application/services/useMode';
+import { log } from 'console';
+import axios from 'axios';
 
 const presetService = new PresetService(presetRepository);
 const presetListService = new PresetListService(presetListRepository);
@@ -39,6 +41,25 @@ function usePreset() {
   });
 
   useEffect(() => {
+    // 나중에 지울 코드!
+    // await axios
+    //   .get('http://localhost:3000/user-information/getAllPreSet', {
+    //     withCredentials: true,
+    //   })
+    //   .then((res) => {
+    //     const deletePreset = async (id: string) => {
+    //       await axios.delete(
+    //         'http://localhost:3000/user-information/deleteOnePreSet/${id}',
+    //         {
+    //           withCredentials: true,
+    //         },
+    //       );
+    //     };
+    //     for (let i = 0; i < res.data.length; i++) {
+    //       deletePreset(res.data[i].id);
+    //       console.log('deletePreset : ', res.data[i].id);
+    //     }
+    //   });
     const fetchPresetList = async () => {
       const presetList = await presetListService.getPresetList();
       if (presetList.presetInfos.length !== 0) {
@@ -52,7 +73,7 @@ function usePreset() {
   }, []);
 
   useEffect(() => {
-    if (preset) {
+    if (preset && preset.data) {
       boardDataStore.setBoardData(preset.data.boardData);
       sectionDatasStore.setSectionDatas(preset.data.sectionDatas);
       stickerDatasStore.setStickerDatas(preset.data.stickerDatas);

--- a/packages/client/src/dashboard/application/services/usePreset.tsx
+++ b/packages/client/src/dashboard/application/services/usePreset.tsx
@@ -41,25 +41,6 @@ function usePreset() {
   });
 
   useEffect(() => {
-    // 나중에 지울 코드!
-    // await axios
-    //   .get('http://localhost:3000/user-information/getAllPreSet', {
-    //     withCredentials: true,
-    //   })
-    //   .then((res) => {
-    //     const deletePreset = async (id: string) => {
-    //       await axios.delete(
-    //         'http://localhost:3000/user-information/deleteOnePreSet/${id}',
-    //         {
-    //           withCredentials: true,
-    //         },
-    //       );
-    //     };
-    //     for (let i = 0; i < res.data.length; i++) {
-    //       deletePreset(res.data[i].id);
-    //       console.log('deletePreset : ', res.data[i].id);
-    //     }
-    //   });
     const fetchPresetList = async () => {
       const presetList = await presetListService.getPresetList();
       if (presetList.presetInfos.length !== 0) {
@@ -116,6 +97,10 @@ function usePreset() {
     setControlMode('edit');
   };
 
+  // const deletePreset = async (id: string) => {
+  //   await presetService.deletePreset(id);
+  // };
+
   const changePresetLabel = async (id: string, label: string) => {
     const presetData = await presetService.getPreset(id);
     if (presetData && presetList) {
@@ -137,7 +122,14 @@ function usePreset() {
       });
     }
   };
-  return { preset, presetList, createPreset, changePreset, changePresetLabel };
+  return {
+    preset,
+    presetList,
+    createPreset,
+    changePreset,
+    // deletePreset,
+    changePresetLabel,
+  };
 }
 
 export default usePreset;

--- a/packages/client/src/dashboard/domain/preset/preset.repository.interface.ts
+++ b/packages/client/src/dashboard/domain/preset/preset.repository.interface.ts
@@ -4,7 +4,7 @@ interface PresetRepositoryInterface {
   getPreset(id: string): Promise<PresetType | null>;
   setPreset(preset: PresetType): Promise<void>;
   addPreset(preset: PresetType): Promise<void>;
-  // deletePreset(id: string): Promise<void>;
+  deletePreset(id: string): Promise<void>;
 }
 
 export default PresetRepositoryInterface;

--- a/packages/client/src/dashboard/domain/preset/preset.service.ts
+++ b/packages/client/src/dashboard/domain/preset/preset.service.ts
@@ -16,9 +16,9 @@ class PresetService {
     return this.presetRepository.addPreset(preset);
   }
 
-  // deletePreset(id: string): Promise<void> {
-  //   return this.presetRepository.deletePreset(id);
-  // }
+  public async deletePreset(id: string): Promise<void> {
+    return this.presetRepository.deletePreset(id);
+  }
 }
 
 export default PresetService;

--- a/packages/client/src/dashboard/infrastructure/http/axios/axios.instance.ts
+++ b/packages/client/src/dashboard/infrastructure/http/axios/axios.instance.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 export const instance = axios.create({
-  baseURL: 'http://dashboard42.com:3000',
+  // baseURL: 'http://dashboard42.com:3000',
+  baseURL: 'http://localhost:3000',
   withCredentials: true,
   timeout: 5000,
   validateStatus: function (status) {

--- a/packages/client/src/dashboard/infrastructure/http/axios/axios.instance.ts
+++ b/packages/client/src/dashboard/infrastructure/http/axios/axios.instance.ts
@@ -1,8 +1,7 @@
 import axios from 'axios';
 
 export const instance = axios.create({
-  // baseURL: 'http://dashboard42.com:3000',
-  baseURL: 'http://localhost:3000',
+  baseURL: 'http://dashboard42.com:3000',
   withCredentials: true,
   timeout: 5000,
   validateStatus: function (status) {

--- a/packages/client/src/dashboard/infrastructure/preset.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/preset.repository.ts
@@ -33,7 +33,7 @@ class PresetRepository implements PresetRepositoryInterface {
       });
     if (isExist) {
       await axios.put(
-        'http://localhost:3000/user-information/updateOnePreSet/${id}',
+        `http://localhost:3000/user-information/updateOnePreSet/${id}`,
         preset,
         {
           withCredentials: true,
@@ -48,6 +48,16 @@ class PresetRepository implements PresetRepositoryInterface {
         },
       );
     }
+  }
+
+  public async deletePreset(id: string): Promise<void> {
+    await axios
+      .delete(`http://localhost:3000/user-information/deleteOnePreset/${id}`, {
+        withCredentials: true,
+      })
+      .then((res) => {
+        console.log('delete result: ', res);
+      });
   }
 }
 

--- a/packages/client/src/dashboard/infrastructure/preset.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/preset.repository.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
 class PresetRepository implements PresetRepositoryInterface {
   public async getPreset(id: string): Promise<PresetType | null> {
     const preset = await axios
-      .get(`http://localhost:3000/user-information/getOnePreSet/${id}`, {
+      .get(`http://dashboard42.com:3000/user-information/getOnePreSet/${id}`, {
         withCredentials: true,
       })
       .then((res) => {
@@ -23,7 +23,7 @@ class PresetRepository implements PresetRepositoryInterface {
     const { id } = preset;
     let isExist = false;
     await axios
-      .get('http://localhost:3000/user-information/getAllPreSet', {
+      .get('http://dashboard42.com:3000/user-information/getAllPreSet', {
         withCredentials: true,
       })
       .then((res) => {
@@ -33,7 +33,7 @@ class PresetRepository implements PresetRepositoryInterface {
       });
     if (isExist) {
       await axios.put(
-        `http://localhost:3000/user-information/updateOnePreSet/${id}`,
+        `http://dashboard42.com:3000/user-information/updateOnePreSet/${id}`,
         preset,
         {
           withCredentials: true,
@@ -41,7 +41,7 @@ class PresetRepository implements PresetRepositoryInterface {
       );
     } else {
       await axios.post(
-        'http://localhost:3000/user-information/addPreSet',
+        'http://dashboard42.com:3000/user-information/addPreSet',
         preset,
         {
           withCredentials: true,
@@ -52,9 +52,12 @@ class PresetRepository implements PresetRepositoryInterface {
 
   public async deletePreset(id: string): Promise<void> {
     await axios
-      .delete(`http://localhost:3000/user-information/deleteOnePreset/${id}`, {
-        withCredentials: true,
-      })
+      .delete(
+        `http://dashboard42.com:3000/user-information/deleteOnePreset/${id}`,
+        {
+          withCredentials: true,
+        },
+      )
       .then((res) => {
         console.log('delete result: ', res);
       });

--- a/packages/client/src/dashboard/infrastructure/presetList.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/presetList.repository.ts
@@ -17,6 +17,7 @@ class PresetListRepository implements PresetListRepositoryInterface {
           presetInfos.push(res.data[i].info);
         }
       });
+    console.log('presetList: ', presetInfos);
     return { presetInfos };
   }
 

--- a/packages/client/src/dashboard/infrastructure/presetList.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/presetList.repository.ts
@@ -9,7 +9,7 @@ class PresetListRepository implements PresetListRepositoryInterface {
     const presetInfos = Array<PresetInfoType>();
 
     await axios
-      .get('http://localhost:3000/user-information/getAllPreSet', {
+      .get('http://dashboard42.com:3000/user-information/getAllPreSet', {
         withCredentials: true,
       })
       .then((res) => {

--- a/packages/client/src/dashboard/infrastructure/presetList.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/presetList.repository.ts
@@ -2,19 +2,21 @@ import PresetType, { PresetInfoType } from './../domain/preset/preset.type';
 import PresetListRepositoryInterface from '../domain/presetList/presetList.repository.interface';
 import PresetListType from '../domain/presetList/presetList.type';
 import presetlistStore from './store/presetList.store';
+import axios from 'axios';
 
 class PresetListRepository implements PresetListRepositoryInterface {
   public async getPresetList(): Promise<PresetListType> {
-    // 여기가 http로 Preset List 받아오는거
     const presetInfos = Array<PresetInfoType>();
 
-    for (let i = 0; i < localStorage.length; ++i) {
-      const key = localStorage.key(i);
-      if (key && key.includes('preset')) {
-        const preset = JSON.parse(localStorage.getItem(key)!) as PresetType;
-        presetInfos.push(preset.info);
-      }
-    }
+    await axios
+      .get('http://localhost:3000/user-information/getAllPreSet', {
+        withCredentials: true,
+      })
+      .then((res) => {
+        for (let i = 0; i < res.data.length; i++) {
+          presetInfos.push(res.data[i].info);
+        }
+      });
     return { presetInfos };
   }
 

--- a/packages/client/src/dashboard/presentation/components/Board/Section.tsx
+++ b/packages/client/src/dashboard/presentation/components/Board/Section.tsx
@@ -35,14 +35,17 @@ export default function Section(props: SectionProps) {
   function drawStickers() {
     return stickerLayouts.map((sticker: Layout, idx) => (
       <div key={sticker.i}>
-        <Sticker
-          id={sticker.i}
-          data={stickerDatas[idx].data}
-          handleStickerRemove={(stickerId) => {
-            removeSticker(stickerId);
-            handleStickerRemove(id, stickerId);
-          }}
-        />
+        {/* TODO(sonkang) : 나중에 더 좋은 방법을 찾아보기 */}
+        {stickerDatas[idx] && (
+          <Sticker
+            id={sticker.i}
+            data={stickerDatas[idx].data}
+            handleStickerRemove={(stickerId) => {
+              removeSticker(stickerId);
+              handleStickerRemove(id, stickerId);
+            }}
+          />
+        )}
       </div>
     ));
   }

--- a/packages/client/src/dashboard/presentation/components/SideBar/PresetListItem.tsx
+++ b/packages/client/src/dashboard/presentation/components/SideBar/PresetListItem.tsx
@@ -1,10 +1,12 @@
 import { SvgIconComponent } from '@mui/icons-material';
 import { ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
 import useMode from '../../../application/services/useMode';
 import { useState } from 'react';
 import TextField from '@mui/material/TextField';
-
+import useBoard from '../../../application/services/useBoard';
+import usePreset from '../../../application/services/usePreset';
 export interface PresetListItemProps {
   icon: SvgIconComponent; // mui/icons-material 에 있는 아이콘 타입
   label: string;
@@ -20,12 +22,18 @@ function PresetListItem(props: PresetListItemProps) {
   const [edit, setEdit] = useState(false);
   const [presetLabel, setPresetLabel] = useState(label);
   const { getControlMode } = useMode();
+  const { handleDeletePreset } = useBoard();
   const IconType = icon;
 
   function myOnClickHandler(e: any) {
     e.stopPropagation();
     changePresetLabel(id, presetLabel);
     setEdit(!edit);
+  }
+
+  async function deletePreset(id: string) {
+    await handleDeletePreset(id);
+    console.log('deletePreset: ', id);
   }
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -38,7 +46,11 @@ function PresetListItem(props: PresetListItemProps) {
       selected={selected || false}
     >
       <ListItemIcon>
-        <IconType />
+        {selected && getControlMode() === 'edit' && !edit ? (
+          <DeleteIcon color="disabled" onClick={() => deletePreset(id)} />
+        ) : (
+          <IconType />
+        )}
       </ListItemIcon>
       {selected && getControlMode() === 'edit' && !edit ? (
         <>

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -44,7 +44,7 @@ export class AuthController {
     const access_token = await this.authService.authentication(code);
     res.cookie('access_token', `${access_token}`, {
       httpOnly: true,
-      // domain: 'dashboard42.com',
+      domain: 'localhost',
     }); //res.cookie()는 하나만 적용됨. 여러개 호출하면 제일 마지막에 호출된것만 적용됨(??)
     // res.setHeader('WWW-authenticate', `Bearer: realm="DashBoard"`);
     res.redirect('http://localhost:3000/auth/test'); //redirection해도 됨. 나중에 front Home으로 redirection되게 할 예정.

--- a/packages/server/src/auth/auth.controller.ts
+++ b/packages/server/src/auth/auth.controller.ts
@@ -47,8 +47,8 @@ export class AuthController {
       domain: 'localhost',
     }); //res.cookie()는 하나만 적용됨. 여러개 호출하면 제일 마지막에 호출된것만 적용됨(??)
     // res.setHeader('WWW-authenticate', `Bearer: realm="DashBoard"`);
-    res.redirect('http://localhost:3000/auth/test'); //redirection해도 됨. 나중에 front Home으로 redirection되게 할 예정.
-    // res.redirect('http://www.dashboard42.com:3000/dashboard'); //for hybae
+    // res.redirect('http://localhost:3000/auth/test'); //redirection해도 됨. 나중에 front Home으로 redirection되게 할 예정.
+    res.redirect('http://www.dashboard42.com:3000/dashboard'); //for hybae
     // res.send('login success!!');
   }
 

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -44,130 +44,37 @@ type JoinedTable {
 }
 
 type Mutation {
-  deleteUserInformation(
-    column: String!
-    entityName: String!
-    intra_no: Int!
-    pk: Int!
-    value: String!
-  ): Boolean!
-  recoverUserInformaiton(
-    column: String!
-    entityName: String!
-    intra_no: Int!
-    pk: Int!
-    value: String!
-  ): Boolean!
-  softDeleteRemoveWithdrawTest(
-    column: String!
-    entityName: String!
-    intra_no: Int!
-    pk: Int!
-    value: String!
-  ): [JoinedTable!]!
-  updateUserInformation(
-    column: String!
-    entityName: String!
-    intra_no: Int!
-    pk: Int!
-    value: String!
-  ): Boolean!
+  deleteUserInformation(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
+  recoverUserInformaiton(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
+  softDeleteRemoveWithdrawTest(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): [JoinedTable!]!
+  updateUserInformation(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
 }
 
 type Query {
   extractDataIntoSpreadsheet: String!
   getDataToModifyFromDB(sheetName: String!): String!
-  getDomainOfColumnFilter(
-    endDate: DateTime
-    filters: [Filter!]!
-    skip: Int
-    startDate: DateTime
-    take: Int
-  ): [JoinedTable!]!
+  getDomainOfColumnFilter(endDate: DateTime, filters: [Filter!]!, skip: Int, startDate: DateTime, take: Int): [JoinedTable!]!
   getLatestData: String!
-  getNumOfPeopleByFilter(
-    endDate: DateTime
-    filters: [Filter!]!
-    skip: Int
-    startDate: DateTime
-    take: Int
-  ): Int!
-  getPeopleByFilter(
-    endDate: DateTime
-    filters: [Filter!]!
-    skip: Int
-    startDate: DateTime
-    take: Int
-  ): [JoinedTable!]!
-  getPeopleByFilterForAdmin(
-    endDate: DateTime
-    filters: [Filter!]!
-    skip: Int
-    startDate: DateTime
-    take: Int
-  ): [JoinedTable!]!
+  getNumOfPeopleByFilter(endDate: DateTime, filters: [Filter!]!, skip: Int, startDate: DateTime, take: Int): Int!
+  getPeopleByFilter(endDate: DateTime, filters: [Filter!]!, skip: Int, startDate: DateTime, take: Int): [JoinedTable!]!
+  getPeopleByFilterForAdmin(endDate: DateTime, filters: [Filter!]!, skip: Int, startDate: DateTime, take: Int): [JoinedTable!]!
   getUser(column: String, duplicated: String!): [User!]!
-  getUserAccessCardInformation(
-    column: String
-    duplicated: String!
-  ): [UserAccessCardInformation!]!
+  getUserAccessCardInformation(column: String, duplicated: String!): [UserAccessCardInformation!]!
   getUserBlackhole(column: String, duplicated: String!): [UserBlackhole!]!
-  getUserComputationFund(
-    column: String
-    duplicated: String!
-  ): [UserComputationFund!]!
-  getUserCourseExtension(
-    column: String
-    duplicated: String!
-  ): [UserCourseExtension!]!
-  getUserEducationFundState(
-    column: String
-    duplicated: String!
-  ): [UserEducationFundState!]!
-  getUserEmploymentStatus(
-    column: String
-    duplicated: String!
-  ): [UserEmploymentStatus!]!
-  getUserHrdNetUtilize(
-    column: String
-    duplicated: String!
-  ): [UserHrdNetUtilize!]!
-  getUserHrdNetUtilizeConsent(
-    column: String
-    duplicated: String!
-  ): [UserHrdNetUtilizeConsent!]!
-  getUserInterruptionOfCourse(
-    column: String
-    duplicated: String!
-  ): [UserInterruptionOfCourse!]!
-  getUserLapiscineInformation(
-    column: String
-    duplicated: String!
-  ): [UserLapiscineInformation!]!
-  getUserLearningDataAPI(
-    column: String
-    duplicated: String!
-  ): [UserLearningDataAPI!]!
-  getUserLeaveOfAbsence(
-    column: String
-    duplicated: String!
-  ): [UserLeaveOfAbsence!]!
-  getUserLoyaltyManagement(
-    column: String
-    duplicated: String!
-  ): [UserLoyaltyManagement!]!
-  getUserOtherEmploymentStatus(
-    column: String
-    duplicated: String!
-  ): [UserOtherEmploymentStatus!]!
-  getUserOtherInformation(
-    column: String
-    duplicated: String!
-  ): [UserOtherInformation!]!
-  getUserPersonalInformation(
-    column: String
-    duplicated: String!
-  ): [UserPersonalInformation!]!
+  getUserComputationFund(column: String, duplicated: String!): [UserComputationFund!]!
+  getUserCourseExtension(column: String, duplicated: String!): [UserCourseExtension!]!
+  getUserEducationFundState(column: String, duplicated: String!): [UserEducationFundState!]!
+  getUserEmploymentStatus(column: String, duplicated: String!): [UserEmploymentStatus!]!
+  getUserHrdNetUtilize(column: String, duplicated: String!): [UserHrdNetUtilize!]!
+  getUserHrdNetUtilizeConsent(column: String, duplicated: String!): [UserHrdNetUtilizeConsent!]!
+  getUserInterruptionOfCourse(column: String, duplicated: String!): [UserInterruptionOfCourse!]!
+  getUserLapiscineInformation(column: String, duplicated: String!): [UserLapiscineInformation!]!
+  getUserLearningDataAPI(column: String, duplicated: String!): [UserLearningDataAPI!]!
+  getUserLeaveOfAbsence(column: String, duplicated: String!): [UserLeaveOfAbsence!]!
+  getUserLoyaltyManagement(column: String, duplicated: String!): [UserLoyaltyManagement!]!
+  getUserOtherEmploymentStatus(column: String, duplicated: String!): [UserOtherEmploymentStatus!]!
+  getUserOtherInformation(column: String, duplicated: String!): [UserOtherInformation!]!
+  getUserPersonalInformation(column: String, duplicated: String!): [UserPersonalInformation!]!
   saveModifiedDataFromSheet(sheetName: String!): String!
   sendRequestToSpreadWithGoogleAPI: String!
   tempFunction: [JoinedTable!]!

--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -44,36 +44,130 @@ type JoinedTable {
 }
 
 type Mutation {
-  deleteUserInformation(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
-  recoverUserInformaiton(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
-  softDeleteRemoveWithdrawTest(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): [JoinedTable!]!
-  updateUserInformation(column: String!, entityName: String!, intra_no: Int!, pk: Int!, value: String!): Boolean!
+  deleteUserInformation(
+    column: String!
+    entityName: String!
+    intra_no: Int!
+    pk: Int!
+    value: String!
+  ): Boolean!
+  recoverUserInformaiton(
+    column: String!
+    entityName: String!
+    intra_no: Int!
+    pk: Int!
+    value: String!
+  ): Boolean!
+  softDeleteRemoveWithdrawTest(
+    column: String!
+    entityName: String!
+    intra_no: Int!
+    pk: Int!
+    value: String!
+  ): [JoinedTable!]!
+  updateUserInformation(
+    column: String!
+    entityName: String!
+    intra_no: Int!
+    pk: Int!
+    value: String!
+  ): Boolean!
 }
 
 type Query {
   extractDataIntoSpreadsheet: String!
   getDataToModifyFromDB(sheetName: String!): String!
-  getDomainOfColumnFilter(endDate: DateTime, filters: [Filter!]!, skip: Int, startDate: DateTime, take: Int): [JoinedTable!]!
+  getDomainOfColumnFilter(
+    endDate: DateTime
+    filters: [Filter!]!
+    skip: Int
+    startDate: DateTime
+    take: Int
+  ): [JoinedTable!]!
   getLatestData: String!
-  getNumOfPeopleByFilter(endDate: DateTime, filters: [Filter!]!, skip: Int, startDate: DateTime, take: Int): Int!
-  getPeopleByFilter(endDate: DateTime, filters: [Filter!]!, skip: Int, startDate: DateTime, take: Int): [JoinedTable!]!
-  getPeopleByFilterForAdmin(endDate: DateTime, filters: [Filter!]!, skip: Int, startDate: DateTime, take: Int): [JoinedTable!]!
+  getNumOfPeopleByFilter(
+    endDate: DateTime
+    filters: [Filter!]!
+    skip: Int
+    startDate: DateTime
+    take: Int
+  ): Int!
+  getPeopleByFilter(
+    endDate: DateTime
+    filters: [Filter!]!
+    skip: Int
+    startDate: DateTime
+    take: Int
+  ): [JoinedTable!]!
+  getPeopleByFilterForAdmin(
+    endDate: DateTime
+    filters: [Filter!]!
+    skip: Int
+    startDate: DateTime
+    take: Int
+  ): [JoinedTable!]!
   getUser(column: String, duplicated: String!): [User!]!
-  getUserAccessCardInformation(column: String, duplicated: String!): [UserAccessCardInformation!]!
+  getUserAccessCardInformation(
+    column: String
+    duplicated: String!
+  ): [UserAccessCardInformation!]!
   getUserBlackhole(column: String, duplicated: String!): [UserBlackhole!]!
-  getUserComputationFund(column: String, duplicated: String!): [UserComputationFund!]!
-  getUserCourseExtension(column: String, duplicated: String!): [UserCourseExtension!]!
-  getUserEmploymentStatus(column: String, duplicated: String!): [UserEmploymentStatus!]!
-  getUserHrdNetUtilize(column: String, duplicated: String!): [UserHrdNetUtilize!]!
-  getUserHrdNetUtilizeConsent(column: String, duplicated: String!): [UserHrdNetUtilizeConsent!]!
-  getUserInterruptionOfCourse(column: String, duplicated: String!): [UserInterruptionOfCourse!]!
-  getUserLapiscineInformation(column: String, duplicated: String!): [UserLapiscineInformation!]!
-  getUserLearningDataAPI(column: String, duplicated: String!): [UserLearningDataAPI!]!
-  getUserLeaveOfAbsence(column: String, duplicated: String!): [UserLeaveOfAbsence!]!
-  getUserLoyaltyManagement(column: String, duplicated: String!): [UserLoyaltyManagement!]!
-  getUserOtherEmploymentStatus(column: String, duplicated: String!): [UserOtherEmploymentStatus!]!
-  getUserOtherInformation(column: String, duplicated: String!): [UserOtherInformation!]!
-  getUserPersonalInformation(column: String, duplicated: String!): [UserPersonalInformation!]!
+  getUserComputationFund(
+    column: String
+    duplicated: String!
+  ): [UserComputationFund!]!
+  getUserCourseExtension(
+    column: String
+    duplicated: String!
+  ): [UserCourseExtension!]!
+  getUserEducationFundState(
+    column: String
+    duplicated: String!
+  ): [UserEducationFundState!]!
+  getUserEmploymentStatus(
+    column: String
+    duplicated: String!
+  ): [UserEmploymentStatus!]!
+  getUserHrdNetUtilize(
+    column: String
+    duplicated: String!
+  ): [UserHrdNetUtilize!]!
+  getUserHrdNetUtilizeConsent(
+    column: String
+    duplicated: String!
+  ): [UserHrdNetUtilizeConsent!]!
+  getUserInterruptionOfCourse(
+    column: String
+    duplicated: String!
+  ): [UserInterruptionOfCourse!]!
+  getUserLapiscineInformation(
+    column: String
+    duplicated: String!
+  ): [UserLapiscineInformation!]!
+  getUserLearningDataAPI(
+    column: String
+    duplicated: String!
+  ): [UserLearningDataAPI!]!
+  getUserLeaveOfAbsence(
+    column: String
+    duplicated: String!
+  ): [UserLeaveOfAbsence!]!
+  getUserLoyaltyManagement(
+    column: String
+    duplicated: String!
+  ): [UserLoyaltyManagement!]!
+  getUserOtherEmploymentStatus(
+    column: String
+    duplicated: String!
+  ): [UserOtherEmploymentStatus!]!
+  getUserOtherInformation(
+    column: String
+    duplicated: String!
+  ): [UserOtherInformation!]!
+  getUserPersonalInformation(
+    column: String
+    duplicated: String!
+  ): [UserPersonalInformation!]!
   saveModifiedDataFromSheet(sheetName: String!): String!
   sendRequestToSpreadWithGoogleAPI: String!
   tempFunction: [JoinedTable!]!

--- a/packages/server/src/user_information/user_information.controller.ts
+++ b/packages/server/src/user_information/user_information.controller.ts
@@ -171,9 +171,9 @@ export class UserInformationController {
     // 당연히 bocal에서도 삭제될것. (실제 DB에서 fk를 가진 튜플을 삭제한거니까)
     // 이 경우는 onDelete 옵션 안써도 되는거
     const preSet = await preSetRepository.delete({
-      id: Equal(uuid),
+      id: uuid,
     });
-    if (preSet) return 'entity not found!';
+    if (!preSet) return 'entity not found!';
     return 'delete success';
   }
 

--- a/packages/server/src/user_information/user_information.controller.ts
+++ b/packages/server/src/user_information/user_information.controller.ts
@@ -128,7 +128,7 @@ export class UserInformationController {
     for (const index in bocal['preSetArray']) {
       ret[index] = {};
       const onePreSet = bocal['preSetArray'][index];
-      ret[index]['id'] = JSON.parse(onePreSet['id']);
+      ret[index]['id'] = onePreSet['id'];
       ret[index]['data'] = JSON.parse(onePreSet['preSetData']);
       ret[index]['info'] = JSON.parse(onePreSet['info']);
     }
@@ -153,7 +153,7 @@ export class UserInformationController {
     for (const index in bocal['preSetArray']) {
       ret[index] = {};
       const onePreSet = bocal['preSetArray'][index];
-      ret[index]['id'] = JSON.parse(onePreSet['id']);
+      ret[index]['id'] = onePreSet['id'];
       ret[index]['data'] = JSON.parse(onePreSet['preSetData']);
       ret[index]['info'] = JSON.parse(onePreSet['info']);
     }
@@ -178,23 +178,30 @@ export class UserInformationController {
   }
 
   @Put('/updateOnePreSet/:uuid')
-  @ApiParam({
+  // @ApiParam({
+  //   required: true,
+  //   name: 'uuid',
+  // })
+  @ApiBody({
     required: true,
-    name: 'uuid',
   })
   @UseGuards(AuthGuard('jwt'))
-  async updateOnePreSet(@Param('uuid') uuid, @Body() body) {
+  async updateOnePreSet(@Body() body) {
+    const uuid = body['id'];
     const preSetRepository = await this.dataSource.getRepository(PreSet);
+    if (!(await preSetRepository.findOne({ where: { id: Equal(uuid) } }))) {
+      return 'entity not found';
+    }
     const preSet = await preSetRepository.update(
       {
-        id: Equal(uuid),
+        id: uuid,
       },
       {
         preSetData: JSON.stringify(body['data']),
         info: JSON.stringify(body['info']),
       },
     );
-    if (!preSet) return 'entity not found';
+    console.log(preSet);
     return 'update success';
   }
 }


### PR DESCRIPTION
### 작업 동기 (Motivation)
- 로컬에 저장하던 프리셋 데이터를 DB로 옮겼습니다.

### 변경 사항 요약 (Key changes)
- 적용된 변경 사항 요약
  - 백엔드 api를 사용하여 프리셋 저장, 수정, 삭제를 할 수 있게 하였습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항
아직 dashboard42.com으로 프리셋 api가 되지 않기 때문에 임시로 로컬에 백엔드 서버를 올려서 완성하였습니다. 추후 도메인에 프리셋 api가 사용 가능할 때 붙이도록 하겠습니다!
usePreset에서 deletePreset 함수를 만들고 싶었는데 usePreset 내에서 무한 렌더링이되어 임시로 useBoard에 만들었습니다.
추후 수정되어야 할 사항입니다.
- [ ] deletePreset함수 useBoard에서 usePreset으로 옮기기
- [ ] 삭제버튼을 누르면 sidebar와 Board가 재렌더링이 되도록 하기

#368 