### PR TITLE
feat(server/modify): feat: add modify exception

### DIFF
--- a/packages/server/src/schema.gql
+++ b/packages/server/src/schema.gql
@@ -25,7 +25,6 @@ type JoinedTable {
   intra_no: Int!
   name: String
   start_process_date: DateTime
-  start_process: DateTime
   uniqueness: String
   userAccessCardInformation: [UserAccessCardInformation!]
   userBlackhole: [UserBlackhole!]
@@ -93,7 +92,7 @@ type User {
   expired_date: DateTime!
   grade: String!
   intra_id: String!
-  intra_no: Int!
+  intra_no: Float!
   name: String!
   start_process_date: DateTime!
   uniqueness: String!
@@ -104,9 +103,9 @@ type UserAccessCardInformation {
   created_date: DateTime!
   deleted_date: DateTime!
   expired_date: DateTime!
-  lapiscine_logical_number: Int!
-  lapiscine_physical_number: Int!
-  logical_number_for_main_course: Int!
+  lapiscine_logical_number: String!
+  lapiscine_physical_number: String!
+  logical_number_for_main_course: String!
   name_of_entry_card_for_main_course: String!
   pk: Int!
   profile_picture_path: String!

--- a/packages/server/src/spread/msg/errorMsg.msg.ts
+++ b/packages/server/src/spread/msg/errorMsg.msg.ts
@@ -1,0 +1,19 @@
+export interface ErrorMsg {
+  colIdx: string;
+  value: string;
+  rowIdx: number;
+}
+
+export function formatError(repoName, contents, errorMsg) {
+  return `[Sheet] ${repoName}\n[Contents] ${contents}\n[Index] \'${errorMsg.colIdx}:${errorMsg.rowIdx}\'의 '${errorMsg.value}' 값을 수정해주세요.`;
+}
+
+export const enum ERRORMSG {
+  COLUMNS = '컬럼의 이름이 변경되었거나, 수가 변동되었습니다.',
+  DUPLICATE = '기본키의 값이 중복되었습니다.',
+  INTERRUPT = '기존 데이터베이스의 값이 변동되었습니다',
+  CHANGED = '최신 데이터가 수정되었습니다.',
+  INSERT = '삽입된 데이터의 날짜와 형식을 확인해주세요',
+  UPDATE = '갱신된 데이터의 날짜와 형식을 확인해주세요',
+  SUCCESS = '수정된 데이터가 성공적으로 저장되었습니다.',
+}

--- a/packages/server/src/updater/name_types/updater.name.ts
+++ b/packages/server/src/updater/name_types/updater.name.ts
@@ -11,12 +11,18 @@ import {
   SUB_COMPUTATIONFUND2022_ID,
   SUB_EDUCATIONFUNDSTATE_ID,
   SUB_EMPLOYMENTSTATUS_ID,
+  SUB_HRDNETUTILIZE_22_1_ID,
+  SUB_HRDNETUTILIZE_22_2_ID,
+  SUB_HRDNETUTILIZE_22_3_ID,
+  SUB_HRDNETUTILIZE_22_4_ID,
+  SUB_HRDNETUTILIZE_22_5_ID,
+  SUB_HRDNETUTILIZE_22_6_ID,
   SUB_HRDNETUTILIZE_CONSENT_ID,
-  SUB_HRDNETUTILIZE_ID,
   SUB_INTERRUPTIONOFCOURSE_ID,
   SUB_LEAVEOFABSENCE_ID,
   SUB_LEVEL_API_ID,
-  SUB_LOYALTYMANAGEMENT_ID,
+  SUB_LOYALTYMANAGEMENT_22_1_ID,
+  SUB_LOYALTYMANAGEMENT_22_2_ID,
   SUB_OTHEREMPLOYMENTSTATUS_ID,
 } from 'src/config/key';
 import { UserAccessCardInformation } from 'src/user_information/entity/user_access_card_information.entity';
@@ -275,7 +281,7 @@ export const pastDataOnSheet = [
   {
     // 로열티 관리
     endPoint: SPREAD_END_POINT,
-    Id: [SUB_LOYALTYMANAGEMENT_ID],
+    Id: [SUB_LOYALTYMANAGEMENT_22_1_ID, SUB_LOYALTYMANAGEMENT_22_2_ID],
     columns: mapObj[TABLENUM.USERLOYALTYMANAGEMENT],
     table: TABLENUM.USERLOYALTYMANAGEMENT,
   },
@@ -296,7 +302,14 @@ export const pastDataOnSheet = [
   {
     // HRD-Net_data
     endPoint: SPREAD_END_POINT,
-    Id: [SUB_HRDNETUTILIZE_ID],
+    Id: [
+      SUB_HRDNETUTILIZE_22_1_ID,
+      SUB_HRDNETUTILIZE_22_2_ID,
+      SUB_HRDNETUTILIZE_22_3_ID,
+      SUB_HRDNETUTILIZE_22_4_ID,
+      SUB_HRDNETUTILIZE_22_5_ID,
+      SUB_HRDNETUTILIZE_22_6_ID,
+    ],
     columns: mapObj[TABLENUM.USERHRDNETUTILIZE],
     table: TABLENUM.USERHRDNETUTILIZE,
   },
@@ -406,19 +419,19 @@ export const defaultVALUE = {
     academic_state: 'BLACK_HOLE',
     start_process_date: '9999-12-31',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_personal_information: {
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_course_extension: {
     basic_expiration_date: '9999-12-31',
     final_expiration_date: '9999-12-31',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_leave_of_absence: {
@@ -426,7 +439,7 @@ export const defaultVALUE = {
     end_absence_date: '9999-12-31',
     return_from_absence_date: '9999-12-31',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_blackhole: {
@@ -434,12 +447,12 @@ export const defaultVALUE = {
     blackhost_date: '9999-12-31',
     blackholed_level: 0,
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_interruption_of_course: {
     break_date: '9999-12-31', //이름 변경 요망validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_learnig_data_api: {
@@ -452,7 +465,7 @@ export const defaultVALUE = {
     outcircle: 'N',
     outcircled_date: '9999-12-31',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_loyalty_management: {
@@ -460,21 +473,21 @@ export const defaultVALUE = {
     royalty_presence: 'N',
     royalty_circle: 0,
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_employment_status: {
     employment_date: '9999-12-31',
-    employment: '미취업',
+    employmented: '미취업',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_hrd_net_utilize_consent: {
     consent_to_provide_information: 'N',
     consented_date: '9999-12-31',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_hrd_net_utilize: {
@@ -482,13 +495,13 @@ export const defaultVALUE = {
     employmented: 'N',
     employment_insurance_date: '9999-12-31',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_other_employment_status: {
     employment_date: '9999-12-31',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_education_fund_state: {
@@ -497,7 +510,7 @@ export const defaultVALUE = {
     payment_end_date: '9999-12-31',
     //uniqueness: '0',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   //하위시트에서 받아올 때는 makeAColumnInTable에서 초기화를 함
@@ -506,7 +519,7 @@ export const defaultVALUE = {
     received: 'N',
     recevied_amount: 0,
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_access_card_information: {},
@@ -514,7 +527,7 @@ export const defaultVALUE = {
   user_other_information: {
     majored: '비전공',
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 
   user_lapiscine_information: {
@@ -524,7 +537,7 @@ export const defaultVALUE = {
     // participate_lapicin: 9999,
     // number_of_rapicin_participation: 9999,
     validate_date: '9999-12-31',
-    expired_date: '999-12-31',
+    expired_date: '9999-12-31',
   },
 };
 

--- a/packages/server/src/updater/updater.service.ts
+++ b/packages/server/src/updater/updater.service.ts
@@ -189,7 +189,6 @@ export class UpdaterService {
     }
     const latestData = await this.getLatestData();
     await this.compareNewDataWithLatestData(tableArray, latestData);
-
     return await 'All data has been updated';
   }
 

--- a/packages/server/src/user_job/entity/user_job.entity.ts
+++ b/packages/server/src/user_job/entity/user_job.entity.ts
@@ -25,6 +25,7 @@ export class UserOtherEmploymentStatus extends BaseEntity {
     name: 'employment_date',
     nullable: false,
     default: '9999-12-31',
+    type: 'timestamptz',
   })
   employment_date: Date;
 


### PR DESCRIPTION


### 작업 동기 (Motivation)
데이터 수정을 간편하게 하기 위해 구글 스프레드 상에서 작업을 할 수 있도록 환경을 구축하였습니다.
자유도가 높은 구글 스프레드 환경에서 작업할 시, 수 많은 에러가 예상 될 수 있기에 예외처리를 추가해줬습니다.


### 변경 사항 요약 (Key changes)
- 수정시트를 관리할때 발생할 수 있는 에러에 대해 예외처리를 추가해줬습니다


```tsx
COLUMNS = '컬럼의 이름이 변경되었거나, 수가 변동되었습니다.',
  DUPLICATE = '기본키의 값이 중복되었습니다.',
  INTERRUPT = '기존 데이터베이스의 값이 변동되었습니다',
  CHANGED = '최신 데이터가 수정되었습니다.',
  INSERT = '삽입된 데이터의 날짜와 형식을 확인해주세요',
  UPDATE = '갱신된 데이터의 날짜와 형식을 확인해주세요',
  SUCCESS = '수정된 데이터가 성공적으로 저장되었습니다.',
```

- **컬럼**(**청록색 데이터**)의 이름을 변경할 수 없습니다.
- 데이터베이스의 **기본키(PK) 및 외래키(fk_user_no)** (**분홍색 데이터**)의 값을 수정할 수 없습니다.
- 데이터베이스의 **최신 데이터**(**보라색 데이터**)를 변경할 수 없습니다.
- 새로운 값을 삽입할 경우 항상 **최신데이터**(**보라색 데이터**)보다 이전 시점이어야합니다.
- 기존 값을 변경할 경우 항상 **최신데이터**(**보라색 데이터**)보다 이전 시점이어야합니다.
