### PR TITLE
feat(client/modal): modal 중간에 멈출 시 데이터 리셋, stepper 현재 step 표시

### DIFF
--- a/packages/client/src/dashboard/presentation/components/Modal/Modal.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/Modal.tsx
@@ -9,6 +9,8 @@ import {
   makeChartStickerData,
   makeTextStickerData,
 } from './makeStickerData';
+import { resetApolloContext } from '@apollo/client';
+import { SettingsBackupRestoreTwoTone } from '@mui/icons-material';
 
 interface ModalProps {
   sectionId: string;
@@ -40,6 +42,7 @@ const ModalFrame = (props: ModalProps) => {
   const [filters, setFilters] = useState<FilterConfigType[]>([]);
   const [datasets, setDatasets] = useState<FilterConfigType[][]>([[]]);
   const [datasetNames, setDatasetNames] = useState<string[]>([]);
+  const [reset, setReset] = useState(false);
 
   /** switch to type & handle properly */
   function AddStickerDataset() {
@@ -91,7 +94,10 @@ const ModalFrame = (props: ModalProps) => {
   return (
     <Modal
       open={isOpen}
-      onClose={() => setIsOpen(false)}
+      onClose={() => {
+        setIsOpen(false);
+        setReset(true);
+      }}
       style={{
         position: 'relative',
         left: 'calc(50vw - 250px)',
@@ -112,6 +118,8 @@ const ModalFrame = (props: ModalProps) => {
           datasetNames={datasetNames}
           setDatasetNames={setDatasetNames}
           applyFiltersModal={AddStickerDataset}
+          reset={reset}
+          setReset={setReset}
         />
       </Box>
     </Modal>

--- a/packages/client/src/dashboard/presentation/components/Modal/StickerStepper.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/StickerStepper.tsx
@@ -142,12 +142,9 @@ export default function StickerStepper(props: ModalDatasType) {
       <Stepper activeStep={activeStep}>
         {steps.map((label, index) => {
           const stepProps: { completed?: boolean } = {};
-          const labelProps: {
-            optional?: React.ReactNode;
-          } = {};
           return (
             <Step key={label} {...stepProps}>
-              <StepLabel {...labelProps}>{label}</StepLabel>
+              <StepLabel>{label}</StepLabel>
             </Step>
           );
         })}

--- a/packages/client/src/dashboard/presentation/components/Modal/StickerStepper.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/StickerStepper.tsx
@@ -12,6 +12,8 @@ import { FilterConfigType } from '../Sticker/Filter.type';
 import { useMemo } from 'react';
 import StepButtons from './stepper/StepButtons';
 import StepHeader from './stepper/StepHeader';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
 
 const StyledDiv = styled.div`
   height: 550px;
@@ -28,6 +30,8 @@ interface ModalDatasType {
   setDatasetNames: React.Dispatch<React.SetStateAction<string[]>>;
   setDatasets: React.Dispatch<React.SetStateAction<FilterConfigType[][]>>;
   applyFiltersModal: () => void;
+  reset: boolean;
+  setReset: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function StickerStepper(props: ModalDatasType) {
@@ -41,6 +45,8 @@ export default function StickerStepper(props: ModalDatasType) {
     datasetNames,
     setDatasetNames,
     applyFiltersModal,
+    reset,
+    setReset,
   } = props;
 
   const [steps, setSteps] = React.useState<string[]>(['Type 정하기!']);
@@ -103,7 +109,8 @@ export default function StickerStepper(props: ModalDatasType) {
   }, [type]);
 
   function returnStep() {
-    if (activeStep === 0) {
+    if (activeStep === 0 || reset === true) {
+      setReset(false);
       return <TypeBox handleType={setType} />;
     } else if (activeStep === 1) {
       return (
@@ -133,7 +140,17 @@ export default function StickerStepper(props: ModalDatasType) {
   return (
     <Box sx={{ width: '100%' }}>
       <Stepper activeStep={activeStep}>
-        <StepHeader activeStep={activeStep} steps={steps} />
+        {steps.map((label, index) => {
+          const stepProps: { completed?: boolean } = {};
+          const labelProps: {
+            optional?: React.ReactNode;
+          } = {};
+          return (
+            <Step key={label} {...stepProps}>
+              <StepLabel {...labelProps}>{label}</StepLabel>
+            </Step>
+          );
+        })}
       </Stepper>
       {activeStep === steps.length ? <LastStepPage /> : returnStep()}
       <StepButtons


### PR DESCRIPTION
### 작업 동기 (Motivation)
- modal에서 데이터 설정을 하던 중, modal을 끄고 다시 켜면 데이터가 남아있었습니다.
- stepper에서 현재 step을 알 수 없었습니다. 
### 변경 사항 요약 (Key changes)
- 적용된 변경 사항 요약
  - useState를 사용하여 데이터 설정 중 modal이 꺼졌었는지 확인합니다.
  - 현재 step을 알 수 있게 했습니다.
### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [x] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

feat #365 #366