### PR TITLE
fix(client): hotfix, initial dataset is not render

### DIFF
--- a/packages/client/src/dashboard/presentation/components/Modal/Modal.tsx
+++ b/packages/client/src/dashboard/presentation/components/Modal/Modal.tsx
@@ -98,7 +98,7 @@ const ModalFrame = (props: ModalProps) => {
     setType('none');
     setLabels([]);
     setFilters([]);
-    setDatasets([]);
+    setDatasets([[]]);
     setDatasetNames([]);
   }
 


### PR DESCRIPTION
### 작업 동기 (Motivation)

### 변경 사항 요약 (Key changes)
🐛 버그 픽스인 경우 :
- 모달창이 랜더가 일어나서 초기화가 일어날 경우 이중배열이 아니라 일차원 배열로 초기화가 되서 첫 데이터셋이 랜더가 안됐습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

