### PR TITLE
feat(client): apply datasetnaming to pie and bar chart 

### DIFF
--- a/packages/client/src/dashboard/presentation/components/Board/Section.tsx
+++ b/packages/client/src/dashboard/presentation/components/Board/Section.tsx
@@ -70,7 +70,7 @@ export default function Section(props: SectionProps) {
       <ReactGridLayout
         onDragStart={(a, b, c, d, e) => e.stopPropagation()}
         layouts={{ lg: stickerLayouts }}
-        breakpoints={{ lg: 600, md: 498, sm: 384, xs: 240, xxs: 0 }}
+        breakpoints={{ lg: 600 }}
         cols={{ lg: 8, md: 5, sm: 4, xs: 2, xxs: 1 }}
         onLayoutChange={(newLayout) => {
           handleStickerLayoutChange(id, newLayout);

--- a/packages/client/src/dashboard/presentation/components/Charts/BarChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/BarChart.tsx
@@ -6,7 +6,7 @@ import useChartDataset from '../../../application/services/useDataset';
 Chart.register(...registerables);
 
 export default function BarChart(props: ChartProps) {
-  const { labels, queryData, options } = props;
+  const { labels, queryData, datasetNames, options } = props;
   const { data, loading, error } = useChartDataset(queryData);
   const datasets = [];
   const defaultOptions = {
@@ -23,7 +23,8 @@ export default function BarChart(props: ChartProps) {
   }
   const barData = {
     labels,
-    datasets: datasets.map((dataset) => ({
+    datasets: datasets.map((dataset, idx) => ({
+      label: datasetNames[idx],
       data: dataset,
       backgroundColor: ['#36A2EB', '#FF6384'],
     })),

--- a/packages/client/src/dashboard/presentation/components/Charts/PieChart.tsx
+++ b/packages/client/src/dashboard/presentation/components/Charts/PieChart.tsx
@@ -6,7 +6,7 @@ import { ChartProps } from './ChartData';
 Chart.register(...registerables);
 
 export default function PieChart(props: ChartProps) {
-  const { labels, queryData, options } = props;
+  const { labels, queryData, datasetNames, options } = props;
   const { data, loading, error } = useChartDataset(queryData);
   const datasets = [];
   const defaultOptions = {
@@ -23,8 +23,8 @@ export default function PieChart(props: ChartProps) {
   }
   const pieData = {
     labels,
-    datasets: datasets.map((dataset) => ({
-      label: 'Test',
+    datasets: datasets.map((dataset, idx) => ({
+      label: datasetNames[idx],
       data: dataset,
       backgroundColor: ['#36A2EB', '#FF6384'],
     })),

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "TZ=Asia/Seoul nest start",
-    "start:dev": "nest start --watch",
+    "start:dev": "TZ=Asia/Seoul nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",


### PR DESCRIPTION
### 작업 동기 (Motivation)
* 데이터셋에 이름 넣고 하는데 파이랑 바 차트는 적용이 안되더군요.

### 변경 사항 요약 (Key changes)
🐛 버그 픽스인 경우 :
- 파이와 바 차트에 데이터셋 이름을 적용했고
- 섹션에 브레이크 포인트도 삭제 했습니다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

