### PR TITLE
feat(server/updater): 학습데이터 기준 일자 변경

### DIFF
--- a/packages/server/src/updater/name_types/updater.name.ts
+++ b/packages/server/src/updater/name_types/updater.name.ts
@@ -366,7 +366,7 @@ export const oldDateTable = {
   [repoKeys.userLeaveOfAbsence]: 'begin_absence_date',
   [repoKeys.userBlackhole]: 'validate_date',
   [repoKeys.userInterruptionOfCourse]: 'validate_date',
-  [repoKeys.userLearningDataAPI]: 'validate_date',
+  [repoKeys.userLearningDataAPI]: 'manyDateTable', //날짜 저장의 기준이 여러개인 table
   [repoKeys.userLoyaltyManagement]: 'validate_date',
   [repoKeys.userEmploymentStatus]: 'employment_date',
   [repoKeys.userHrdNetUtilizeConsent]: 'consented_date',
@@ -395,6 +395,15 @@ export const dateTable = {
   [repoKeys.userAccessCardInformation]: 'validate_date',
   [repoKeys.userOtherInformation]: 'validate_date',
   [repoKeys.userLapiscineInformation]: 'validate_date',
+};
+
+export const manyDateTable = {
+  [repoKeys.userLearningDataAPI]: [
+    'scored_date',
+    'circled_date',
+    'leveled_date',
+    'outcircled_date',
+  ],
 };
 
 export const classType = {

--- a/packages/server/src/updater/updater.service.ts
+++ b/packages/server/src/updater/updater.service.ts
@@ -46,6 +46,7 @@ import { ErrorObject } from 'src/auth/entity/bocal.entity';
 import { EntityColumn } from 'src/common/EntityColumn';
 import { APIS } from 'googleapis/build/src/apis';
 import { entityArray } from 'src/user_information/utils/getDomain.utils';
+import { ExceptionsHandler } from '@nestjs/core/exceptions/exceptions-handler';
 
 interface RepoDict {
   [repositoryName: string]:
@@ -568,7 +569,7 @@ export class UpdaterService {
       }
       return returnArray;
     } catch {
-      throw 'eere';
+      throw ExceptionsHandler;
     }
   }
 


### PR DESCRIPTION
### 작업 동기 (Motivation)
프론트에서 최신 값을 불러올 때 validate_date로 값을 불러오고 있습니다.
과거 데이터의 기준을 validate_date로 명확하게 지정하고자 하였습니다.

✨ 그 외의 경우 :
- 적용된 변경 사항 요약
학습데이터의 로깅 값을 저장할 때 기준이 되는 날짜를 확인하여 validate_date에 초기화


### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).


