### PR TITLE
fix(client): refetch when modify spread sheet

### DIFF
--- a/packages/client/src/dashboard/application/services/useBoard.tsx
+++ b/packages/client/src/dashboard/application/services/useBoard.tsx
@@ -30,6 +30,7 @@ function useBoard() {
     const sectionDatas: SectionDataType[] = sectionDatasStore.getSectionDatas();
     const stickerDatas: StickerDataType[] = stickerDatasStore.getStickerDatas();
     console.log(boardData, sectionDatas, stickerDatas);
+    //make preset data to save in db
     const presetData = {
       boardData,
       sectionDatas,

--- a/packages/client/src/dashboard/presentation/components/Common/EditToolBar.tsx
+++ b/packages/client/src/dashboard/presentation/components/Common/EditToolBar.tsx
@@ -51,7 +51,7 @@ export const BoardEditToolBar = (props: BoardEditToolBarProps) => {
         <IconAdd style={{ width: '1rem' }} />
       </Button>
       <Button
-        onClick={handleSavePreset}
+        onClick={handleSavePreset} // TODO save preset label.
         style={{ position: 'absolute', right: '0' }}
       >
         <IconSave style={{ width: '1rem' }} />

--- a/packages/client/src/dashboard/presentation/components/Dialog/EntityListItem.tsx
+++ b/packages/client/src/dashboard/presentation/components/Dialog/EntityListItem.tsx
@@ -26,11 +26,6 @@ export default function EntityListItem(props: EntityListItemProps) {
     setSave(false);
   }
 
-  function retrySave(e: any) {
-    e.stopPropagation();
-    setRetry((prev) => !prev);
-  }
-
   return (
     <ListItem
       button
@@ -48,7 +43,7 @@ export default function EntityListItem(props: EntityListItemProps) {
       )}
       {save && (
         <RequestButton
-          retrySave={retrySave}
+          retrySave={setRetry}
           withDeleted={withDeleted}
           entityName={entityName}
           checkSucessSave={checkSucessSave}

--- a/packages/client/src/dashboard/presentation/components/Dialog/RequestButton.tsx
+++ b/packages/client/src/dashboard/presentation/components/Dialog/RequestButton.tsx
@@ -9,15 +9,18 @@ export interface RequestButtonProps {
   entityName: keyof typeof tableName;
   withDeleted: boolean;
   checkSucessSave: (e: any) => void;
-  retrySave: (e: any) => void;
+  retrySave: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const SUCCESS = '수정된 데이터가 성공적으로 저장되었습니다.';
 
 export default function RequestButton(props: RequestButtonProps) {
   const { entityName, withDeleted, checkSucessSave, retrySave } = props;
-  const { data, loading, error } = useQuery(
+  const { data, loading, error, refetch } = useQuery(
     createSaveModifiedDataQuery(entityName, withDeleted ? 'Y' : 'N'),
+    {
+      fetchPolicy: 'no-cache',
+    },
   );
 
   if (error) return <Button disabled={true}>{error.message}.</Button>;
@@ -35,7 +38,11 @@ export default function RequestButton(props: RequestButtonProps) {
       alert(data['saveModifiedDataFromSheet']);
       return (
         <Alert
-          onClick={retrySave}
+          onClick={async (e) => {
+            e.stopPropagation();
+            await refetch();
+            retrySave((prev) => !prev);
+          }}
           icon={<SaveIcon fontSize="inherit" />}
           severity="info"
         ></Alert>

--- a/packages/client/src/dashboard/presentation/components/Dialog/SaveButton.tsx
+++ b/packages/client/src/dashboard/presentation/components/Dialog/SaveButton.tsx
@@ -3,6 +3,7 @@ import SaveIcon from '@mui/icons-material/Save';
 import createModificationDataQuery from '../../../infrastructure/http/graphql/createModificationDataQuery';
 import { useQuery } from '@apollo/client';
 import { tableName } from 'common/src';
+import { useEffect } from 'react';
 
 export interface SaveButtonProps {
   entityName: keyof typeof tableName;
@@ -15,6 +16,9 @@ export default function SaveButton(props: SaveButtonProps) {
 
   const { data, loading, error } = useQuery(
     createModificationDataQuery(entityName, withDeleted ? 'Y' : 'N'),
+    {
+      fetchPolicy: 'no-cache',
+    },
   );
 
   if (error) return <Alert severity="error">{error.message}</Alert>;


### PR DESCRIPTION
### 작업 동기 (Motivation)

### 변경 사항 요약 (Key changes)
🐛 버그 픽스인 경우 :
- 버그를 재현하는 방법?
  - 스프레드시트를 잘못 수정 후에 저장을 누르면 에러가 발생한다.
  - 이후 다시 수정사항을 되돌리고 나서 다시 요청을 보내도 같은 에러가 발생했다.
- 어떻게 해결했는가?
  - gql을 쓰다보니 캐시가 적용되서 적용되는 캐쉬 정책을 바꿔주었다.

### 미흡한점
- 로딩중에 다른 스피닝다이얼을 띄워주지 않고 있다.
- 그냥 rest api요청으로 해결할 수 있다면 좋을듯.싶기도 하다.

### 체크리스트
- [ ] 각 기능에 대한 단위 테스트 및 통합 테스트를 수정|업데이트|추가했습니다(해당되는 경우).
- [ ] 콘솔에 오류나 경고가 없습니다.
- [ ] 개발된 기능의 스크린샷에 참여했습니다(해당되는 경우).

### 스크린샷 첨부

### 리뷰어들에게 요청사항

