### PR TITLE
feat(client): axios로 401 error받았을 때 login 페이지로 라우팅

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -7,6 +7,7 @@ import {
   getControlMode,
   setControlMode,
 } from './dashboard/application/services/useMode';
+import { Interceptor } from './dashboard/infrastructure/http/axios/axios.instance';
 const Colors = {
   cyan: '#65C2C2',
   magenta: '#EA6390',
@@ -77,10 +78,12 @@ document.addEventListener('keyup', (event) => {
 function App() {
   return (
     <div className="App">
-      <Routes>
-        <Route path="/" element={<Login />} />
-        <Route path="/dashboard" element={<DashBoardPage />} />
-      </Routes>
+      <Interceptor>
+        <Routes>
+          <Route path="/" element={<Login />} />
+          <Route path="/dashboard" element={<DashBoardPage />} />
+        </Routes>
+      </Interceptor>
     </div>
   );
 }

--- a/packages/client/src/dashboard/infrastructure/http/axios/axios.custom.ts
+++ b/packages/client/src/dashboard/infrastructure/http/axios/axios.custom.ts
@@ -1,4 +1,5 @@
 import * as axios from './axios.instance';
+import PresetType from '../../../domain/preset/preset.type';
 
 // login api의 url
 const getUserInfoURL = '/auth/userInfo';
@@ -40,6 +41,58 @@ export const axiosGetError = async () => {
   try {
     const response = await axios.instance.get(getErrorURL);
     return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const getOnePresetURL = `${process.env.REACT_APP_GET_ONE_PRESET}/`;
+
+export const axiosGetOnePreset = async (id: string) => {
+  try {
+    const response = await axios.instance.get(getOnePresetURL + id);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const getAllPresetURL = `${process.env.REACT_APP_GET_ALL_PRESET}`;
+
+export const axiosGetAllPreset = async () => {
+  try {
+    const response = await axios.instance.get(getAllPresetURL);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const updatePresetURL = `${process.env.REACT_APP_UPDATE_ONE_PRESET}/`;
+
+export const axiosUpdatePreset = async (id: string, preset: PresetType) => {
+  try {
+    await axios.instance.put(updatePresetURL + id, preset);
+  } catch (error) {
+    throw error;
+  }
+};
+
+const addPresetURL = `${process.env.REACT_APP_ADD_PRESET}`;
+
+export const axiosAddPreset = async (preset: PresetType) => {
+  try {
+    await axios.instance.post(addPresetURL, preset);
+  } catch (error) {
+    throw error;
+  }
+};
+
+const deletePresetURL = `${process.env.REACT_APP_DELETE_ONE_PRESET}/`;
+
+export const axiosDeletePreset = async (id: string) => {
+  try {
+    await axios.instance.delete(deletePresetURL + id);
   } catch (error) {
     throw error;
   }

--- a/packages/client/src/dashboard/infrastructure/http/axios/axios.instance.ts
+++ b/packages/client/src/dashboard/infrastructure/http/axios/axios.instance.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import useUser from '../../../application/services/useUser';
 
 export const instance = axios.create({
   baseURL: `${process.env.REACT_APP_API_URI}`,
@@ -8,3 +9,23 @@ export const instance = axios.create({
     return status >= 200 && status < 300;
   },
 });
+
+const Interceptor = ({ children }: any) => {
+  const { setUser } = useUser();
+
+  instance.interceptors.response.use(
+    function (response) {
+      return response;
+    },
+    async function (error) {
+      console.log(error.response.status);
+      if (error.response?.status === 401) {
+        await setUser(null);
+        window.location.href = '/';
+      }
+    },
+  );
+  return children;
+};
+
+export { Interceptor };

--- a/packages/client/src/dashboard/infrastructure/preset.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/preset.repository.ts
@@ -1,21 +1,19 @@
 import PresetRepositoryInterface from '../domain/preset/preset.repository.interface';
 import PresetType from '../domain/preset/preset.type';
 import presetStore from './store/preset.store';
-import axios from 'axios';
-
+import {
+  axiosGetOnePreset,
+  axiosGetAllPreset,
+  axiosUpdatePreset,
+  axiosAddPreset,
+  axiosDeletePreset,
+} from './http/axios/axios.custom';
 class PresetRepository implements PresetRepositoryInterface {
   public async getPreset(id: string): Promise<PresetType | null> {
-    const preset = await axios
-      .get(
-        `${process.env.REACT_APP_API_URI}${process.env.REACT_APP_GET_ONE_PRESET}/${id}`,
-        {
-          withCredentials: true,
-        },
-      )
-      .then((res) => {
-        console.log('get result from db', res);
-        return res.data[0];
-      });
+    const preset = await axiosGetOnePreset(id).then((res) => {
+      console.log('get result from db', res);
+      return res.data[0];
+    });
     return preset;
   }
 
@@ -26,49 +24,21 @@ class PresetRepository implements PresetRepositoryInterface {
   public async savePreset(preset: PresetType): Promise<void> {
     const { id } = preset;
     let isExist = false;
-    await axios
-      .get(
-        `${process.env.REACT_APP_API_URI}${process.env.REACT_APP_GET_ALL_PRESET}`,
-        {
-          withCredentials: true,
-        },
-      )
-      .then((res) => {
-        for (let i = 0; i < res.data.length; i++) {
-          if (res.data[i].id === id) isExist = true;
-        }
-      });
+    await axiosGetAllPreset().then((res) => {
+      for (let i = 0; i < res.data.length; i++) {
+        if (res.data[i].id === id) isExist = true;
+      }
+    });
     if (isExist) {
-      await axios.put(
-        `${process.env.REACT_APP_API_URI}${process.env.REACT_APP_UPDATE_ONE_PRESET}/${id}`,
-        preset,
-        {
-          withCredentials: true,
-        },
-      );
+      await axiosUpdatePreset(id, preset);
     }
     if (!isExist) {
-      await axios.post(
-        `${process.env.REACT_APP_API_URI}${process.env.REACT_APP_ADD_PRESET}`,
-        preset,
-        {
-          withCredentials: true,
-        },
-      );
+      await axiosAddPreset(preset);
     }
   }
 
   public async deletePreset(id: string): Promise<void> {
-    await axios
-      .delete(
-        `${process.env.REACT_APP_API_URI}${process.env.REACT_APP_DELETE_ONE_PRESET}/${id}`,
-        {
-          withCredentials: true,
-        },
-      )
-      .then((res) => {
-        console.log('delete result: from db ', res);
-      });
+    await axiosDeletePreset(id);
   }
 }
 

--- a/packages/client/src/dashboard/infrastructure/presetList.repository.ts
+++ b/packages/client/src/dashboard/infrastructure/presetList.repository.ts
@@ -2,24 +2,17 @@ import { PresetInfoType } from './../domain/preset/preset.type';
 import PresetListRepositoryInterface from '../domain/presetList/presetList.repository.interface';
 import PresetListType from '../domain/presetList/presetList.type';
 import presetlistStore from './store/presetList.store';
-import axios from 'axios';
+import { axiosGetAllPreset } from './http/axios/axios.custom';
 
 class PresetListRepository implements PresetListRepositoryInterface {
   public async getPresetList(): Promise<PresetListType> {
     const presetInfos: PresetInfoType[] = [];
 
-    await axios
-      .get(
-        `${process.env.REACT_APP_API_URI}${process.env.REACT_APP_GET_ALL_PRESET}`,
-        {
-          withCredentials: true,
-        },
-      )
-      .then((res) => {
-        for (let i = 0; i < res.data.length; i++) {
-          presetInfos.push(res.data[i].info);
-        }
-      });
+    await axiosGetAllPreset().then((res) => {
+      for (let i = 0; i < res.data.length; i++) {
+        presetInfos.push(res.data[i].info);
+      }
+    });
     console.log('presetList: from db', presetInfos);
     return { presetInfos };
   }


### PR DESCRIPTION
#523 
### 변경 사항 요약 (Key changes)
- axios를 사용한 곳을 custom axios로 변경
- User 정보를 지워야해서 hook을 사용함
  - axios interceptor 내부에서 hook을 사용하지 못하기 때문에 컴포넌트로 만들어 사용 [🔗](https://velog.io/@soongle/React-hook-axios-axios-interceptor-%EB%82%B4%EB%B6%80%EC%97%90%EC%84%9C-react-hook-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)